### PR TITLE
chore(gitignore): exclude .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -390,3 +390,6 @@ specs/
 
 # Logging
 logs/
+
+# Agent worktrees (local-only, must not be tracked as gitlinks)
+.claude/worktrees/


### PR DESCRIPTION
Prevents Claude-agent worktrees from being tracked as submodule gitlinks.

Ref: vamseeachanta/workspace-hub#2326