### PR TITLE
fix(.claude): resolve merge conflict in .claude/settings.json (#50)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,31 +1,3 @@
-<<<<<<< Updated upstream
-{
-  "hooks": {
-    "PostToolUse": [
-      {
-        "matcher": "Write|Edit|MultiEdit",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "cat | \"${WORKSPACE_HUB:-/mnt/github/workspace-hub}/.claude/hooks/capture-corrections.sh\""
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "statusMessage": "Post-task learning check",
-            "command": "bash -c 'SCRIPT=\"${WORKSPACE_HUB:-$(git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel)}/.claude/hooks/post-task-review.sh\"; [ -f \"$SCRIPT\" ] && bash \"$SCRIPT\" 2>/dev/null || true'"
-          }
-        ]
-      }
-    ]
-  }
-}
-=======
 {
   "env": {
     "CLAUDE_FLOW_AUTO_COMMIT": "false",
@@ -101,6 +73,15 @@
             "command": "cat | jq -r '.tool_input.file_path // .tool_input.path // empty' | tr '\\n' '\\0' | xargs -0 -I {} npx claude-flow@alpha hooks post-edit --file '{}' --format true --update-memory true"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cat | \"${WORKSPACE_HUB:-/mnt/github/workspace-hub}/.claude/hooks/capture-corrections.sh\""
+          }
+        ]
       }
     ],
     "PreCompact": [
@@ -131,6 +112,15 @@
             "command": "npx claude-flow@alpha hooks session-end --generate-summary true --persist-state true --export-metrics true"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "statusMessage": "Post-task learning check",
+            "command": "bash -c 'SCRIPT=\"${WORKSPACE_HUB:-$(git rev-parse --show-superproject-working-tree 2>/dev/null | grep . || git rev-parse --show-toplevel)}/.claude/hooks/post-task-review.sh\"; [ -f \"$SCRIPT\" ] && bash \"$SCRIPT\" 2>/dev/null || true'"
+          }
+        ]
       }
     ]
   },
@@ -141,4 +131,3 @@
     "command": ".claude/statusline-command.sh"
   }
 }
->>>>>>> Stashed changes

--- a/tests/test_settings_clean.py
+++ b/tests/test_settings_clean.py
@@ -1,0 +1,65 @@
+"""Asserts .claude/settings.json is conflict-free and valid JSON.
+
+Filed as durable enforcement against a recurring failure mode. The settings file
+had a single ~143-line conflict block (3 markers) from a stash/rebase that
+combined upstream hooks with stashed env/permissions/Claude-Flow integration;
+resolution landed via issue #50.
+
+Refs: assethold#50, workspace-hub#2411, workspace-hub#2719.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SETTINGS_FILE = REPO_ROOT / ".claude" / "settings.json"
+CLAUDE_DIR = REPO_ROOT / ".claude"
+
+CONFLICT_PATTERN = re.compile(r"^(<<<<<<<|=======|>>>>>>>)", re.MULTILINE)
+
+
+def test_settings_file_exists():
+    """The .claude/settings.json file must exist."""
+    assert SETTINGS_FILE.exists(), f"{SETTINGS_FILE} missing"
+
+
+def test_no_conflict_markers_in_settings():
+    """No git merge-conflict markers may exist in .claude/settings.json."""
+    body = SETTINGS_FILE.read_text(encoding="utf-8")
+    markers = CONFLICT_PATTERN.findall(body)
+    assert len(markers) == 0, (
+        f"{SETTINGS_FILE.relative_to(REPO_ROOT)} contains {len(markers)} conflict marker(s); "
+        f"unresolved merge conflict regression"
+    )
+
+
+def test_settings_parses_as_valid_json():
+    """The .claude/settings.json must parse as valid JSON (was broken pre-resolution)."""
+    body = SETTINGS_FILE.read_text(encoding="utf-8")
+    try:
+        json.loads(body)
+    except json.JSONDecodeError as e:
+        raise AssertionError(
+            f"{SETTINGS_FILE.relative_to(REPO_ROOT)} is not valid JSON: {e}"
+        ) from e
+
+
+def test_settings_has_hooks_section():
+    """Per resolution plan, post-merge file must retain `hooks` section."""
+    config = json.loads(SETTINGS_FILE.read_text(encoding="utf-8"))
+    assert isinstance(config, dict), "settings.json must be a JSON object"
+    assert "hooks" in config, "missing `hooks` section post-merge"
+    assert isinstance(config["hooks"], dict), "`hooks` must be a JSON object"
+
+
+def test_no_conflict_markers_in_other_claude_configs():
+    """Regression guard: no `.claude/*.json` file may contain conflict markers."""
+    bad = []
+    for f in CLAUDE_DIR.glob("*.json"):
+        if CONFLICT_PATTERN.search(f.read_text(encoding="utf-8")):
+            bad.append(f.name)
+    assert not bad, f"Conflict markers in: {bad}"


### PR DESCRIPTION
## Summary

Resolves the unresolved git merge conflict in `.claude/settings.json` (~143-line conflict block with `<<<<<<< Updated upstream / ======= / >>>>>>> Stashed changes` markers). Settings was non-functional JSON pre-fix.

## Resolution — merge-both per #50 plan

The two sides described **complementary** content (neither was a strict superset):
- **Upstream** (lines 1-27): minimal hooks (PostToolUse capture-corrections + Stop post-task-review)
- **Stashed** (lines 29-143): full Claude Flow integration (env vars, permissions allowlist/denylist, comprehensive hooks)

Merged the two sides:
| Key | Source | Notes |
|---|---|---|
| `env` | stashed | upstream had none |
| `permissions` | stashed | upstream had none |
| `hooks.PreToolUse` | stashed | not in upstream |
| `hooks.PostToolUse` | **combined** | claude-flow Bash + Write\|Edit\|MultiEdit hooks from stashed + capture-corrections hook from upstream (different matcher object) |
| `hooks.PreCompact` | stashed | not in upstream |
| `hooks.Stop` | **combined** | session-end hook from stashed + post-task-review hook from upstream (fire at different phases) |
| `includeCoAuthoredBy`, `enabledMcpjsonServers`, `statusLine` | stashed | not in upstream |

Result: 144 → 133 lines; valid JSON with 6 top-level keys; all original hooks preserved.

## Changes

- `.claude/settings.json`: conflict resolved, valid JSON, merge-both intact
- `tests/test_settings_clean.py`: NEW (5 test cases) — durable enforcement: no conflict markers, valid JSON, hooks section present, regression guard on `.claude/*.json`

## Verification

```
$ jq . .claude/settings.json > /dev/null && echo VALID
VALID

$ grep -c "^<<<<<<<\|^=======$\|^>>>>>>>" .claude/settings.json
0

$ uv run --with pytest python -m pytest tests/test_settings_clean.py -o "addopts="
5 passed in 0.11s
```

## Discovery

Surfaced during [`vamseeachanta/workspace-hub#2411`](https://github.com/vamseeachanta/workspace-hub/issues/2411) ecosystem-wide adapter-pattern parity audit (Explore subagent over `assethold/`).

## Test plan
- [x] Pre-fix: 3 conflict markers in `.claude/settings.json`; JSON parse failure verified
- [x] TDD step: test file written matching worldenergydata#414/PR #415 pattern
- [x] Resolution applied (merge-both with explicit per-key retention)
- [x] Post-fix: 0 markers, valid JSON, hooks section present, 5/5 tests pass

Closes #50.