### PR TITLE
docs(realestate): add real-estate investment analysis reference (llm-wiki#118)

### DIFF
--- a/docs/domain/realestate/real-estate-analysis.md
+++ b/docs/domain/realestate/real-estate-analysis.md
@@ -1,0 +1,39 @@
+---
+title: "Real Estate Investment Analysis"
+tags: [finance, real-estate, cap-rate, cash-on-cash, irr, investment]
+sources:
+  - career-learnings
+added: 2026-04-09
+last_updated: 2026-04-09
+---
+
+# Real Estate Investment Analysis
+
+Core financial metrics and analysis methods for evaluating real estate investment opportunities,
+covering cap rate, cash-on-cash return, IRR, and value-add strategies.
+
+## Core Metrics
+
+| Metric | Formula | Purpose |
+|--------|---------|---------|
+| Cap rate | NOI / purchase price | Risk indicator, market benchmark |
+| Cash-on-cash | Annual pre-tax cash flow / total equity invested | Measures leverage effect |
+| IRR | Total return including appreciation, amortisation, cash flow | Hold-period return |
+| DSCR | NOI / debt service | Lender requirement (typically > 1.25) |
+
+## Key Concepts
+
+- **Net lease structures (NNN)**: shift operating expenses to tenant
+- **Value-add plays**: reposition below-market rents; force appreciation via NOI improvement
+- **1031 exchange**: defers capital gains tax on like-kind property swap
+
+## Design Patterns
+
+- Cap rate compression = price appreciation; watch spread vs treasury yields
+- Cash-on-cash < cap rate = negative leverage (common when rates rise)
+- 1031 exchange defers capital gains tax on like-kind property swap
+- Vacancy rate sensitivity: model base/upside/downside scenarios
+
+## Cross-References
+
+- **Related entity**: [[energy-economics]] (NPV and discounted cash flow methodology overlap)


### PR DESCRIPTION
Routes the real-estate investment methodology page from a workspace-hub personal knowledge wiki into assethold, per the llm-wiki#118 re-routing (asset-relevant content → assethold).

- `docs/domain/realestate/real-estate-analysis.md` — cap rate, cash-on-cash, IRR, DSCR, 1031, value-add (generic methodology, no personal holdings)
- Scanned clean (0 internal markers); assethold is public, content is public-safe.