### PR TITLE
feat(market_alerts): live-quote → signals → alerts engine (achantas-data#134)

### DIFF
--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -47,3 +47,11 @@ workflows:
       - examples/workflows/fundamentals/outputs/report.txt
     test: uv run python -m assethold examples/workflows/fundamentals/input.yml
     runtime: uv-python
+  - id: market-alerts-offline
+    basename: market_alerts
+    input: examples/workflows/market-alerts/input.yml
+    outputs:
+      - examples/workflows/market-alerts/outputs/snapshot.csv
+      - examples/workflows/market-alerts/outputs/alerts.json
+    test: uv run python -m assethold examples/workflows/market-alerts/input.yml
+    runtime: uv-python

--- a/examples/workflows/market-alerts/input.yml
+++ b/examples/workflows/market-alerts/input.yml
@@ -1,0 +1,30 @@
+basename: market_alerts
+
+Analysis:
+  result_folder: examples/workflows/market-alerts/outputs
+  file_name: market-alerts-run
+
+# Offline example: deterministic fixture quotes (no network) so the registry test is
+# reproducible. Real runs set data.source: yfinance (see the achantas-data config that
+# consumes this engine with live data + real positions).
+market_alerts:
+  data:
+    source: fixture
+    quotes:
+      XOM:  { price: 110.0, prev_close: 100.0, pe: 12.0, dividend_yield: 0.035 }
+      RIG:  { price: 6.10,  prev_close: 6.00,  pe: 8.0 }
+      BRKB: { price: 400.0, prev_close: 399.0, pe: 9.0, dividend_yield: 0.0 }
+      VOO:  { price: 505.0, prev_close: 500.0, pe: 26.0, dividend_yield: 0.013 }
+  positions:
+    - { ticker: XOM,  usd: 1000 }
+    - { ticker: RIG,  usd: 800 }
+    - { ticker: BRKB, usd: 3000 }
+    - { ticker: VOO,  usd: 2000 }
+  signals:
+    price_move_pct: 1.0
+    fundamentals:
+      pe_max: 30
+      div_yield_min: 3.0
+  outputs:
+    snapshot_csv: examples/workflows/market-alerts/outputs/snapshot.csv
+    alerts_json: examples/workflows/market-alerts/outputs/alerts.json

--- a/examples/workflows/market-alerts/input.yml
+++ b/examples/workflows/market-alerts/input.yml
@@ -21,7 +21,8 @@ market_alerts:
     - { ticker: BRKB, usd: 3000 }
     - { ticker: VOO,  usd: 2000 }
   signals:
-    price_move_pct: 1.0
+    price_move_pct: 1.0       # per-position move vs prev close
+    portfolio_move_pct: 0.5   # book-level (dollar-weighted) move
     fundamentals:
       pe_max: 30
       div_yield_min: 3.0

--- a/src/assethold/base_configs/modules/market_alerts/market_alerts.yml
+++ b/src/assethold/base_configs/modules/market_alerts/market_alerts.yml
@@ -1,0 +1,24 @@
+basename: market_alerts
+
+default:
+  log_level: INFO
+  config:
+    overwrite:
+      output: true
+
+Analysis:
+  result_folder: examples/workflows/market-alerts/outputs
+  file_name: market-alerts-run
+
+market_alerts:
+  data:
+    source: fixture
+  positions: []
+  signals:
+    price_move_pct: 1.0
+    fundamentals:
+      pe_max: 30
+      div_yield_min: 3.0
+  outputs:
+    snapshot_csv: examples/workflows/market-alerts/outputs/snapshot.csv
+    alerts_json: examples/workflows/market-alerts/outputs/alerts.json

--- a/src/assethold/base_configs/modules/market_alerts/market_alerts.yml
+++ b/src/assethold/base_configs/modules/market_alerts/market_alerts.yml
@@ -16,6 +16,7 @@ market_alerts:
   positions: []
   signals:
     price_move_pct: 1.0
+    portfolio_move_pct: 0.5
     fundamentals:
       pe_max: 30
       div_yield_min: 3.0

--- a/src/assethold/engine.py
+++ b/src/assethold/engine.py
@@ -14,6 +14,7 @@ from assethold.modules.dividend_forecast.dividend_forecast import (
     DividendForecastWorkflow,
 )
 from assethold.modules.fundamentals.fundamentals import FundamentalsWorkflow
+from assethold.modules.market_alerts.market_alerts import MarketAlertsWorkflow
 from assethold.modules.options.options import OptionsWorkflow
 from assethold.modules.portfolio.portfolio import PortfolioWorkflow
 from assethold.modules.property.property import PropertyWorkflow
@@ -61,6 +62,9 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         cfg_base = workflow.router(cfg_base)
     elif basename == "fundamentals":
         workflow = FundamentalsWorkflow()
+        cfg_base = workflow.router(cfg_base)
+    elif basename == "market_alerts":
+        workflow = MarketAlertsWorkflow()
         cfg_base = workflow.router(cfg_base)
     else:
         raise Exception(f"Analysis for basename: {basename} not found. ... FAIL")

--- a/src/assethold/modules/market_alerts/market_alerts.py
+++ b/src/assethold/modules/market_alerts/market_alerts.py
@@ -1,0 +1,119 @@
+"""market_alerts workflow: positions + live quotes -> signals -> alerts + snapshot.
+
+Generic engine (no account PII). Positions are dollar-denominated (USD allocation per
+ticker), so portfolio weights and the weighted move come from allocations, not share
+counts. Holdings may be a hypothetical watchlist or sourced from a positions export by
+the caller; this workflow only sees what the cfg provides.
+
+cfg section ("market_alerts"):
+    data:      {source: yfinance|fixture}
+    positions: [{ticker, usd}, ...]
+    signals:   {price_move_pct, fundamentals: {pe_max, div_yield_min}}
+    outputs:   {snapshot_csv, alerts_json}   # paths; the caller decides where
+"""
+from __future__ import annotations
+
+import csv
+from typing import List, Optional
+
+from assethold.modules.market_alerts import signals as signal_rules
+from assethold.modules.market_alerts.marketdata import MarketDataProvider, get_provider
+from assethold.modules.market_alerts.signals import Alert
+from assethold.modules.workflow_io import output_path, record_outputs, section, write_json
+
+
+class MarketAlertsWorkflow:
+    """Fetch quotes for the configured positions, run signals, write snapshot + alerts."""
+
+    def router(self, cfg: dict, provider: Optional[MarketDataProvider] = None) -> dict:
+        settings = section(cfg, "market_alerts")
+        positions = settings.get("positions", []) or []
+        signals_cfg = settings.get("signals", {}) or {}
+        outputs = settings.get("outputs", {}) or {}
+
+        if provider is None:
+            data_cfg = settings.get("data", {}) or {}
+            provider = get_provider(
+                data_cfg.get("source", "yfinance"),
+                quotes=data_cfg.get("quotes", {}),  # used only by the 'fixture' source
+            )
+
+        total = sum(float(p.get("usd", 0)) for p in positions) or 1.0
+        holdings: List[dict] = []
+        alerts: List[Alert] = []
+        weighted_move = 0.0
+        have_move = False
+
+        for p in positions:
+            ticker = p["ticker"]
+            usd = float(p.get("usd", 0))
+            weight = usd / total
+            quote = provider.get_quote(ticker)
+            if quote.pct_change is not None:
+                weighted_move += weight * quote.pct_change
+                have_move = True
+            holdings.append({
+                "ticker": ticker, "usd": usd, "weight": weight,
+                "price": quote.price, "prev_close": quote.prev_close,
+                "pct_change": quote.pct_change, "pe": quote.pe,
+                "dividend_yield": quote.dividend_yield,
+            })
+            alerts.extend(signal_rules.evaluate(quote, signals_cfg))
+
+        portfolio = {
+            "total_usd": total,
+            "weighted_move_pct": weighted_move if have_move else None,
+            "holdings": holdings,
+        }
+
+        written = []
+        if "snapshot_csv" in outputs:
+            written.append(_write_snapshot_csv(outputs["snapshot_csv"], holdings))
+        if "alerts_json" in outputs:
+            written.append(write_json(outputs["alerts_json"], {
+                "total_usd": total,
+                "weighted_move_pct": portfolio["weighted_move_pct"],
+                "alerts": [a.__dict__ for a in alerts],
+            }))
+
+        print(render_console(portfolio, alerts))
+
+        cfg["market_alerts_result"] = {
+            "portfolio": portfolio,
+            "alerts": [a.__dict__ for a in alerts],
+        }
+        return record_outputs(cfg, "market_alerts", written)
+
+
+def _write_snapshot_csv(path: str, holdings: List[dict]):
+    target = output_path(path)
+    cols = ["ticker", "usd", "weight", "price", "prev_close", "pct_change", "pe", "dividend_yield"]
+    with target.open("w", newline="", encoding="utf-8") as fh:
+        w = csv.DictWriter(fh, fieldnames=cols)
+        w.writeheader()
+        for h in holdings:
+            w.writerow({k: h.get(k) for k in cols})
+    return target
+
+
+_SEV_MARK = {"warn": "⚠", "info": "•"}
+
+
+def render_console(portfolio: dict, alerts: List[Alert]) -> str:
+    lines = ["=" * 60, f"Market alerts — portfolio (${portfolio['total_usd']:,.0f})", "=" * 60]
+    lines.append(f"{'Ticker':<8}{'Weight':>8}{'Price':>12}{'Δ% prev':>10}")
+    for h in portfolio["holdings"]:
+        px = f"{h['price']:.2f}" if h["price"] is not None else "n/a"
+        pc = f"{h['pct_change']:+.2f}" if h["pct_change"] is not None else "n/a"
+        lines.append(f"{h['ticker']:<8}{h['weight']*100:>7.1f}%{px:>12}{pc:>10}")
+    pm = portfolio["weighted_move_pct"]
+    lines.append("-" * 60)
+    lines.append(f"Portfolio weighted move: {pm:+.2f}%" if pm is not None else "Portfolio weighted move: n/a")
+    lines.append("")
+    if alerts:
+        lines.append(f"ALERTS ({len(alerts)}):")
+        for a in alerts:
+            lines.append(f"  {_SEV_MARK.get(a.severity, '-')} [{a.kind}] {a.ticker}: {a.message}")
+    else:
+        lines.append("No alerts (all thresholds clear).")
+    return "\n".join(lines)

--- a/src/assethold/modules/market_alerts/market_alerts.py
+++ b/src/assethold/modules/market_alerts/market_alerts.py
@@ -66,6 +66,17 @@ class MarketAlertsWorkflow:
             "holdings": holdings,
         }
 
+        # Book-level move alert: fires when the dollar-weighted portfolio move crosses a
+        # threshold even if no single position does. Useful for a concentrated book.
+        pm = portfolio["weighted_move_pct"]
+        pm_thr = signals_cfg.get("portfolio_move_pct")
+        if pm is not None and pm_thr is not None and abs(pm) >= pm_thr:
+            direction = "up" if pm >= 0 else "down"
+            alerts.append(Alert(
+                "PORTFOLIO", "portfolio_move", "warn",
+                f"book {pm:+.2f}% ({direction}, threshold {pm_thr:g}%)",
+            ))
+
         written = []
         if "snapshot_csv" in outputs:
             written.append(_write_snapshot_csv(outputs["snapshot_csv"], holdings))

--- a/src/assethold/modules/market_alerts/marketdata.py
+++ b/src/assethold/modules/market_alerts/marketdata.py
@@ -1,0 +1,100 @@
+"""Pluggable market-data providers for the market_alerts workflow.
+
+Default provider is yfinance (free, ~15-min delayed, unofficial). The interface is
+deliberately small so a real-time feed (polygon.io, a broker websocket) can be dropped
+in later without touching the signal layer. A FixtureProvider gives deterministic
+offline runs for CI / tests.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional, Protocol
+
+# yfinance uses '-' for share classes (BRK-B); users often type 'BRKB'.
+_TICKER_ALIASES = {"BRKB": "BRK-B", "BRK.B": "BRK-B", "BRKA": "BRK-A"}
+
+
+def normalize_ticker(ticker: str) -> str:
+    t = ticker.strip().upper()
+    return _TICKER_ALIASES.get(t, t)
+
+
+@dataclass
+class Quote:
+    ticker: str
+    price: Optional[float] = None
+    prev_close: Optional[float] = None
+    pe: Optional[float] = None
+    dividend_yield: Optional[float] = None  # fraction, e.g. 0.034 == 3.4%
+    error: Optional[str] = None
+
+    @property
+    def pct_change(self) -> Optional[float]:
+        if self.price is None or not self.prev_close:
+            return None
+        return (self.price - self.prev_close) / self.prev_close * 100.0
+
+
+class MarketDataProvider(Protocol):
+    def get_quote(self, ticker: str) -> Quote: ...
+
+
+class YFinanceProvider:
+    """Live quotes via yfinance: prices from fast_info (reliable); fundamentals
+    (P/E, dividend yield) from .info (best-effort, never sinks the quote)."""
+
+    def get_quote(self, ticker: str) -> Quote:
+        sym = normalize_ticker(ticker)
+        try:
+            import yfinance as yf
+
+            t = yf.Ticker(sym)
+            fi = t.fast_info
+            price = _num(getattr(fi, "last_price", None))
+            prev = _num(getattr(fi, "previous_close", None))
+
+            pe = dy = None
+            try:
+                info = t.info or {}
+                pe = _num(info.get("trailingPE"))
+                # yfinance reports dividendYield in PERCENT (e.g. 2.8 == 2.8%);
+                # store as a fraction.
+                dy_raw = _num(info.get("dividendYield"))
+                dy = dy_raw / 100.0 if dy_raw is not None else None
+            except Exception:  # noqa: BLE001 - best-effort fundamentals
+                pass
+
+            return Quote(ticker=ticker, price=price, prev_close=prev, pe=pe, dividend_yield=dy)
+        except Exception as exc:  # noqa: BLE001 - surface, don't crash the run
+            return Quote(ticker=ticker, error=f"{type(exc).__name__}: {exc}")
+
+
+class FixtureProvider:
+    """Deterministic offline provider. quotes: ticker -> Quote | dict of Quote fields."""
+
+    def __init__(self, quotes: Dict[str, object]):
+        self._quotes: Dict[str, Quote] = {}
+        for k, v in quotes.items():
+            self._quotes[normalize_ticker(k)] = v if isinstance(v, Quote) else Quote(ticker=k, **v)
+
+    def get_quote(self, ticker: str) -> Quote:
+        q = self._quotes.get(normalize_ticker(ticker))
+        return q if q is not None else Quote(ticker=ticker, error="no fixture")
+
+
+def get_provider(name: str, **kwargs) -> MarketDataProvider:
+    if name == "yfinance":
+        return YFinanceProvider()
+    if name == "fixture":
+        return FixtureProvider(kwargs.get("quotes", {}))
+    raise ValueError(f"unknown market-data source: {name!r} (expected 'yfinance' or 'fixture')")
+
+
+def _num(x) -> Optional[float]:
+    try:
+        if x is None:
+            return None
+        f = float(x)
+        return f if f == f else None  # drop NaN
+    except (TypeError, ValueError):
+        return None

--- a/src/assethold/modules/market_alerts/signals.py
+++ b/src/assethold/modules/market_alerts/signals.py
@@ -1,0 +1,54 @@
+"""Signal rules over quotes: price move vs previous close + a few fundamentals rules.
+
+Each rule is pure (quote + thresholds -> list[Alert]) so rules compose and are trivially
+testable. Add MA-crossover / RSI / etc. as more price history is wired in.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from assethold.modules.market_alerts.marketdata import Quote
+
+
+@dataclass
+class Alert:
+    ticker: str
+    kind: str       # "move" | "valuation" | "yield" | "data"
+    severity: str   # "info" | "warn"
+    message: str
+
+
+def evaluate(quote: Quote, signals_cfg: dict) -> List[Alert]:
+    sig = signals_cfg or {}
+    alerts: List[Alert] = []
+
+    if quote.error:
+        return [Alert(quote.ticker, "data", "warn", f"no data ({quote.error})")]
+
+    thr = sig.get("price_move_pct")
+    if thr is not None and quote.pct_change is not None and abs(quote.pct_change) >= thr:
+        direction = "up" if quote.pct_change >= 0 else "down"
+        alerts.append(Alert(
+            quote.ticker, "move", "warn",
+            f"{quote.pct_change:+.2f}% vs prev close ({direction}, threshold {thr:g}%)",
+        ))
+
+    fund = sig.get("fundamentals", {}) or {}
+    pe_max = fund.get("pe_max")
+    if pe_max is not None and quote.pe is not None and quote.pe > pe_max:
+        alerts.append(Alert(
+            quote.ticker, "valuation", "info",
+            f"P/E {quote.pe:.1f} > {pe_max:g} (rich vs target)",
+        ))
+
+    dy_min = fund.get("div_yield_min")  # configured in percent
+    if dy_min is not None and quote.dividend_yield is not None:
+        dy_pct = quote.dividend_yield * 100.0
+        if dy_pct >= dy_min:
+            alerts.append(Alert(
+                quote.ticker, "yield", "info",
+                f"dividend yield {dy_pct:.2f}% >= {dy_min:g}%",
+            ))
+
+    return alerts

--- a/tests/unit/test_market_alerts_workflow.py
+++ b/tests/unit/test_market_alerts_workflow.py
@@ -48,6 +48,21 @@ def test_weighted_move_uses_dollar_weights(tmp_path):
     assert 2.6 < pm < 2.8  # XOM +10% @0.25 + BRKB ~+0.25% @0.75
 
 
+def test_portfolio_move_alert(tmp_path):
+    cfg = _cfg(tmp_path)
+    cfg["market_alerts"]["signals"]["portfolio_move_pct"] = 0.5  # book moves ~2.7%
+    out = MarketAlertsWorkflow().router(cfg, provider=_provider())
+    pmoves = [a for a in out["market_alerts_result"]["alerts"] if a["kind"] == "portfolio_move"]
+    assert len(pmoves) == 1 and pmoves[0]["ticker"] == "PORTFOLIO"
+
+
+def test_no_portfolio_alert_below_threshold(tmp_path):
+    cfg = _cfg(tmp_path)
+    cfg["market_alerts"]["signals"]["portfolio_move_pct"] = 5.0  # book ~2.7% < 5%
+    out = MarketAlertsWorkflow().router(cfg, provider=_provider())
+    assert [a for a in out["market_alerts_result"]["alerts"] if a["kind"] == "portfolio_move"] == []
+
+
 def test_fixture_quotes_from_cfg(tmp_path):
     cfg = _cfg(tmp_path)
     cfg["market_alerts"]["data"] = {

--- a/tests/unit/test_market_alerts_workflow.py
+++ b/tests/unit/test_market_alerts_workflow.py
@@ -1,0 +1,58 @@
+"""Offline tests for the market_alerts workflow (fixture provider, no network)."""
+from assethold.modules.market_alerts.marketdata import FixtureProvider, Quote, normalize_ticker
+from assethold.modules.market_alerts.market_alerts import MarketAlertsWorkflow
+
+
+def _cfg(tmp_path):
+    return {
+        "basename": "market_alerts",
+        "market_alerts": {
+            "data": {"source": "fixture"},
+            "positions": [
+                {"ticker": "XOM", "usd": 1000},
+                {"ticker": "BRKB", "usd": 3000},
+            ],
+            "signals": {"price_move_pct": 1.0, "fundamentals": {"pe_max": 30, "div_yield_min": 3.0}},
+            "outputs": {
+                "snapshot_csv": str(tmp_path / "snapshot.csv"),
+                "alerts_json": str(tmp_path / "alerts.json"),
+            },
+        },
+    }
+
+
+def _provider():
+    return FixtureProvider({
+        "XOM": Quote(ticker="XOM", price=110.0, prev_close=100.0, pe=12.0, dividend_yield=0.035),
+        "BRK-B": Quote(ticker="BRKB", price=400.0, prev_close=399.0, pe=9.0, dividend_yield=0.0),
+    })
+
+
+def test_brkb_alias():
+    assert normalize_ticker("BRKB") == "BRK-B"
+
+
+def test_move_alert_and_outputs_written(tmp_path):
+    cfg = _cfg(tmp_path)
+    out = MarketAlertsWorkflow().router(cfg, provider=_provider())
+    alerts = out["market_alerts_result"]["alerts"]
+    moves = [a for a in alerts if a["kind"] == "move"]
+    assert len(moves) == 1 and moves[0]["ticker"] == "XOM"  # +10% vs prev close
+    assert (tmp_path / "snapshot.csv").exists()
+    assert (tmp_path / "alerts.json").exists()
+
+
+def test_weighted_move_uses_dollar_weights(tmp_path):
+    out = MarketAlertsWorkflow().router(_cfg(tmp_path), provider=_provider())
+    pm = out["market_alerts_result"]["portfolio"]["weighted_move_pct"]
+    assert 2.6 < pm < 2.8  # XOM +10% @0.25 + BRKB ~+0.25% @0.75
+
+
+def test_fixture_quotes_from_cfg(tmp_path):
+    cfg = _cfg(tmp_path)
+    cfg["market_alerts"]["data"] = {
+        "source": "fixture",
+        "quotes": {"XOM": {"price": 110.0, "prev_close": 100.0}, "BRKB": {"price": 400.0, "prev_close": 399.0}},
+    }
+    out = MarketAlertsWorkflow().router(cfg)  # provider built from cfg, not injected
+    assert any(a["kind"] == "move" for a in out["market_alerts_result"]["alerts"])


### PR DESCRIPTION
Generic, PII-free market-alerts engine on the UV-workflow contract — consumed by the private achantas-data repo for live trade alerts (achantas-data#134).

Clean re-cut of #56 onto current main (#55 was squash-merged, which left #56 carrying duplicated commits; this is the same market_alerts work, cherry-picked clean — 9 files, +397).

## Contract
`uv run python -m assethold examples/workflows/market-alerts/input.yml`

## What's here
- `modules/market_alerts/` — pluggable marketdata provider (yfinance default; fixture for offline/CI), pure signals (price move vs prev close + fundamentals: P/E, dividend yield), `MarketAlertsWorkflow.router` → snapshot.csv + alerts.json + console; USD-weighted portfolio move.
- `engine.py` — `market_alerts` basename (fail-closed `else` preserved).
- base config + offline fixture example + registry row `market-alerts-offline` + offline tests (4 pass).

Verified on current main: 4/4 market_alerts tests pass; `dividendYield` normalized percent→fraction.

Part of achantas-data#134 / epic workspace-hub#3050.