### PR TITLE
feat(pages): deploy API reference (scoped to docs/api, no third-party content)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,50 @@
+name: Deploy API Docs to Pages
+
+# Publishes ONLY the auto-generated API reference (docs/api) via mkdocs.pages.yml,
+# which scopes docs_dir to docs/api. The full docs/ tree is intentionally NOT
+# published (it holds third-party PDFs + personal docs — see #59).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'src/**'
+      - 'docs/api/**'
+      - 'mkdocs.yml'
+      - 'mkdocs.pages.yml'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - uses: astral-sh/setup-uv@v7
+      - name: Build API docs (scoped to docs/api)
+        run: uv run --group docs mkdocs build -f mkdocs.pages.yml
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/mkdocs.pages.yml
+++ b/mkdocs.pages.yml
@@ -1,0 +1,19 @@
+# Pages-only MkDocs config — publishes ONLY the auto-generated API reference.
+#
+# Inherits the main mkdocs.yml (theme, mkdocstrings handler, extensions) but
+# overrides docs_dir to docs/api so the published site can ONLY contain the 7
+# API-reference pages. This is deliberate: the full docs/ tree holds 86+
+# third-party PDFs and personal business docs (see assethold#59), and mkdocs
+# copies every file under docs_dir to the output. Scoping docs_dir to docs/api
+# makes a content leak structurally impossible — worst case is a failed build,
+# never publication of docs/.
+INHERIT: mkdocs.yml
+docs_dir: docs/api
+nav:
+  - Overview: index.md
+  - daily_strategy: daily_strategy.md
+  - fundamentals: fundamentals.md
+  - risk_metrics: risk_metrics.md
+  - signals: signals.md
+  - portfolio: portfolio.md
+  - net_lease: net_lease.md


### PR DESCRIPTION
Implements the Pages demo for this repo (#59), part of ecosystem epic vamseeachanta/workspace-hub#3223.

## The constraint
The existing `mkdocs.yml` uses `docs_dir: docs`, and mkdocs copies **every** file under `docs_dir` to the published site. `docs/` holds **86+ third-party PDFs** (Goldman/Citi/Fidelity/McKinsey outlooks, SSRN papers, paid wealth-series workbooks) plus personal business docs — so a wholesale deploy would publish copyrighted + personal material (see #59).

## The fix
A separate **`mkdocs.pages.yml`** that `INHERIT`s the main config but overrides `docs_dir` to **`docs/api`** — so the published site can *only* contain the 7 auto-generated mkdocstrings API-reference pages. Scoping `docs_dir` makes a content leak **structurally impossible** (worst case = failed build, never a `docs/` leak). The repo's existing `docs.yml` is untouched.

`.github/workflows/pages.yml` builds with `mkdocs build -f mkdocs.pages.yml` and deploys. `/site` already gitignored.

Real brokerage data in `reports/` was already outside `docs_dir` — unaffected either way.

## Follow-up (separate)
A curated visualization gallery (synthetic-ticker daily-strategy + multifamily Plotly) can be added later behind the same `docs/api`-scoped safety.

## One-time after merge
Settings → Pages → Source = GitHub Actions.
