### PR TITLE
fix(pages): resolve assetutilities from PyPI (UV_NO_SOURCES)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,6 +34,11 @@ jobs:
           python-version: '3.11'
       - uses: astral-sh/setup-uv@v7
       - name: Build API docs (scoped to docs/api)
+        # UV_NO_SOURCES makes uv resolve the assetutilities dependency from PyPI
+        # instead of the local sibling path (../assetutilities), which doesn't
+        # exist on the CI runner.
+        env:
+          UV_NO_SOURCES: "true"
         run: uv run --group docs mkdocs build -f mkdocs.pages.yml
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
The docs/api Pages build failed in CI because uv tried to resolve the local sibling path dep `../assetutilities` (absent on the runner). Adds `UV_NO_SOURCES: "true"` so uv pulls assetutilities from PyPI. Fixes the deploy for #59.