### PR TITLE
fix(repo-structure): allow mkdocs.pages.yml; unquarantine contract test (#62)

### DIFF
--- a/config/repo_structure.yml
+++ b/config/repo_structure.yml
@@ -50,6 +50,7 @@ allowed_roots:
   - coverage.json
   - .gitignore
   - mkdocs.yml
+  - mkdocs.pages.yml
   - poetry.lock
   - poetry_latest_versions.txt
   - .pre-commit-config.yaml

--- a/scripts/ci/quarantine.txt
+++ b/scripts/ci/quarantine.txt
@@ -14,10 +14,3 @@
 # `tests/`-prefixed and the rootdir-relative unprefixed form for each
 # quarantined test; pytest silently ignores a --deselect that doesn't match the
 # active rootdir, so whichever form is correct wins.
-
-# issue #62 — repo_structure contract missing mkdocs.pages.yml (legitimate tracked
-# repo file from #59/#60 not in config/repo_structure.yml allowed_roots; analog of
-# worldenergydata #524). Proper fix = add mkdocs.pages.yml to allowed_roots
-# (owner-gated per #49); quarantine until then so the PR gate is not blocked.
-tests/repo_structure/test_repo_structure_contract.py::test_current_contract_accepts_approved_roots_and_exceptions
-repo_structure/test_repo_structure_contract.py::test_current_contract_accepts_approved_roots_and_exceptions


### PR DESCRIPTION
Re-lands the real fix for #62. The original fix was pushed to the already-merged #61 branch and lost, so on `main` the repo_structure contract test is still quarantined and the underlying cause was never corrected.

## Problem
`mkdocs.pages.yml` is a legitimately tracked root file (added in #59/#60) but was missing from `allowed_roots` in `config/repo_structure.yml` (`mkdocs.yml` was listed, its `.pages.yml` sibling was not). The repo_structure contract test therefore failed and was quarantined via `scripts/ci/quarantine.txt` (entry referencing #62) — analog of worldenergydata #524.

## Fix
- Add `mkdocs.pages.yml` to `allowed_roots` next to `mkdocs.yml`.
- Remove the now-unnecessary #62 quarantine entries (both `tests/`-prefixed and rootdir-relative forms) from `scripts/ci/quarantine.txt`.

## Verification
`uv run pytest tests/repo_structure -q` → **19 passed, 0 violations** with the quarantine removed (including the previously-quarantined `test_current_contract_accepts_approved_roots_and_exceptions`).

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)