### PR TITLE
ci: add uv caching to python-tests.yml (workspace-hub#3291)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -72,9 +72,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v1
+      uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Install dependencies with uv
       run: |
@@ -210,9 +211,10 @@ jobs:
         python-version: 3.11
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v1
+      uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Install dependencies
       run: |
@@ -252,9 +254,10 @@ jobs:
         python-version: 3.11
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v1
+      uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Install dependencies
       run: |
@@ -302,9 +305,10 @@ jobs:
         python-version: 3.11
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v1
+      uses: astral-sh/setup-uv@v7
       with:
-        version: "latest"
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
 
     - name: Install security tools
       run: |


### PR DESCRIPTION
Implements workspace-hub#3291.

Adds uv dependency caching to all 4 `astral-sh/setup-uv` sites in `.github/workflows/python-tests.yml` (test matrix, integration-tests, financial-data-tests, security): bumps `@v1` -> `@v7`, drops the now-stale `version: "latest"`, and adds `enable-cache: true` + `cache-dependency-glob: "uv.lock"`, copying the worldenergydata `ci.yml` / `domain-matrix.yml` pattern.

The `@v1` -> `@v7` bump is mandatory: `enable-cache` postdates `@v1`, so adding the flag to `@v1` would silently no-op.

Per owner decision D2, `ci.yml` is left unchanged (it inherits caching from the reusable `domain-matrix.yml@main`; it has no local `setup-uv` step).

**Verification:** YAML parses (`yaml.safe_load`); 0 `setup-uv@v1` remain; all 4 sites carry the cache block pinned `@v7`. This workflow's `pull_request` `paths:` filter explicitly lists `.github/workflows/python-tests.yml`, so the PR exercises the workflow; a cache hit is observable in the `setup-uv` step log on a second run over an unchanged `uv.lock`.