### PR TITLE
ci: fix docs.yml startup_failure (workspace-hub#3293)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,6 @@ on:
 jobs:
   docs:
     runs-on: ubuntu-latest
-    if: hashFiles('mkdocs.yml') != ''
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Implements workspace-hub#3293.

Removes the invalid job-level `if: hashFiles('mkdocs.yml') != ''` (line 20) in `.github/workflows/docs.yml` — the identical defect to worldenergydata's docs.yml. `hashFiles()` requires a checked-out workspace that does not exist at job-load time, so the workflow loader rejects the `docs` job and every run is a 0-minute `startup_failure` (run name surfaces as the raw path instead of `Build API Docs`). `mkdocs.yml` is both committed and already in the `on.*.paths` filter, so the guard is doubly redundant.

**Success signal (narrow):** the workflow LOADS and its job EXECUTES (NOT a `startup_failure` / 0-minute parse failure; run `name` resolves to `Build API Docs`). It is **NOT** a green `mkdocs build --strict` — a `--strict` content failure is a normal non-zero-minute `failure`, out of scope for #3293.

**Verification:** YAML parses; `grep hashFiles` → no match; `git diff` is the single-line deletion only. Empirical confirmation is via `gh workflow run docs.yml` (`workflow_dispatch`) — a `docs.yml`-only change matches none of the `on.*.paths` entries, so no organic push/PR triggers it. **Not self-triggered by this PR;** the dispatch verification runs post-merge (operator-gated). No caching change (deferred to #3291 per D2).