### PR TITLE
feat(engine): assethold embed-port (workspace-hub#3308)

### DIFF
--- a/src/assethold/common/configure_embed.py
+++ b/src/assethold/common/configure_embed.py
@@ -1,0 +1,78 @@
+# ABOUTME: Embeddable configuration for assethold's engine (workspace-hub#3308).
+# ABOUTME: Mirrors assetutilities' configure_embed contract (#3297) for assethold's own engine.
+"""Standalone ``configure_embed`` for assethold (workspace-hub#3308).
+
+assethold has no local ``ApplicationManager`` (it imports the installed
+``assetutilities`` package), so unlike #3297 this is a **module-level function**
+(no ``self``, no ``library_name``) that mirrors the canonical #3297 signature
+``configure_embed(cfg, basename, root_folder, log_to_file=False)``.
+
+It makes the caller's in-memory cfg an ``AttributeDict`` and sets, **under the
+injected root**:
+
+- ``Analysis.analysis_root_folder`` -- honored by the ``stocks`` modules and by
+  ``FileManagement.router``.
+- ``Analysis.result_folder`` + ``Analysis.file_name`` -- so the engine's
+  ``save_application_cfg`` cfg-dump lands under root instead of crashing
+  (missing keys) or escaping the root.
+- ``cfg["_config_dir_path"]`` -- per the locked #3297 contract, so any
+  ``PathResolver``-routed / config-relative writes resolve under root and for
+  cross-repo uniformity.
+
+The ``workflow_io.output_path`` family is rebased separately via
+``workflow_io.output_root(root_folder)`` (set by the engine embed branch); this
+function only configures the cfg-driven write mechanisms.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+
+from assetutilities.common.update_deep import AttributeDict
+
+
+def configure_embed(cfg, basename, root_folder, log_to_file=False):
+    """Configure ``cfg`` for an embedded, root-sandboxed engine run.
+
+    Parameters
+    ----------
+    cfg : dict | AttributeDict
+        The caller's in-memory config. Returned as an ``AttributeDict``.
+    basename : str
+        The workflow basename (used for the cfg-dump file name).
+    root_folder : str
+        The injected root; every configured write lands under this dir.
+    log_to_file : bool, default False
+        Carried on ``Analysis`` for #3297 parity. assethold's engine writes no
+        ``.log`` today, so this is informational unless a downstream consumer
+        reads it.
+
+    Raises
+    ------
+    ValueError
+        If ``cfg`` or ``root_folder`` is None.
+    """
+    if cfg is None or root_folder is None:
+        raise ValueError("configure_embed requires both cfg and root_folder")
+
+    cfg = cfg if isinstance(cfg, AttributeDict) else AttributeDict(cfg)
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%Hh%Mm")
+
+    result_folder = os.path.join(root_folder, "results")
+    os.makedirs(result_folder, exist_ok=True)
+
+    # Preserve any caller-provided Analysis keys, then overlay the embed-root keys.
+    analysis = dict(cfg.get("Analysis", {}))
+    analysis.update(
+        {
+            "analysis_root_folder": root_folder,
+            "result_folder": result_folder,
+            "file_name": f"{basename}_{timestamp}",
+            "log_folder": os.path.join(root_folder, "logs"),
+            "log_to_file": log_to_file,
+        }
+    )
+    cfg["Analysis"] = analysis
+    cfg["_config_dir_path"] = root_folder
+    return cfg

--- a/src/assethold/common/provenance.py
+++ b/src/assethold/common/provenance.py
@@ -1,0 +1,49 @@
+# ABOUTME: assethold's own code-version provenance (workspace-hub#3308 AC#3).
+# ABOUTME: Stamps assethold's package version/git sha via assetutilities code_version("assethold").
+"""Provenance helper for assethold (workspace-hub#3308).
+
+AC#3 requires the embed path to stamp **assethold's own** ``{package_version,
+git_sha}`` -- never the assetutilities default. The parameterized
+``code_version(package_name)`` (workspace-hub#3282/#3297) lives in
+``assetutilities.workflow_api``; this thin wrapper passes ``"assethold"``.
+
+An import-guarded local fallback keeps the helper usable even if a stale
+``assetutilities`` lacks ``workflow_api`` (it returns the same shape from
+assethold's ``__version__`` + a local git sha probe).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def _git_sha_or_none() -> str | None:
+    """Best-effort short git sha for the assethold checkout; None if unavailable."""
+    try:
+        here = os.path.dirname(os.path.abspath(__file__))
+        sha = subprocess.check_output(
+            ["git", "-C", here, "rev-parse", "HEAD"],
+            stderr=subprocess.DEVNULL,
+        )
+        return sha.decode().strip() or None
+    except Exception:
+        return None
+
+
+def assethold_code_version() -> dict:
+    """Return assethold's own ``{package_version, git_sha}``.
+
+    Uses the parameterized ``code_version("assethold")`` from
+    ``assetutilities.workflow_api`` when available (#3282/#3297); falls back to
+    assethold's local ``__version__`` + git probe otherwise. NEVER returns the
+    assetutilities default package version.
+    """
+    try:
+        from assetutilities.workflow_api import code_version
+
+        return code_version("assethold")
+    except ImportError:
+        from assethold import __version__
+
+        return {"package_version": __version__, "git_sha": _git_sha_or_none()}

--- a/src/assethold/engine.py
+++ b/src/assethold/engine.py
@@ -21,8 +21,31 @@ from assethold.modules.property.property import PropertyWorkflow
 from assethold.modules.risk_metrics.risk_metrics import RiskMetricsWorkflow
 from assethold.modules.stocks.stocks import Stocks
 
+from assethold.common.configure_embed import configure_embed
+from assethold.modules.workflow_io import output_root
 
-def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) -> dict:
+
+def engine(
+    inputfile: str = None,
+    cfg: dict = None,
+    config_flag: bool = True,
+    root_folder: str = None,
+    log_to_file: bool = True,
+    embed: bool = False,
+) -> dict:
+    """Run an assethold workflow.
+
+    Additive params (workspace-hub#3308, mirroring assetutilities #3297);
+    defaults are byte-identical to today's assethold CLI behavior:
+
+    - ``root_folder`` (default None): the injected sandbox root for the
+      ``embed`` path. All result + cfg-dump writes land under it.
+    - ``log_to_file`` (default True): carried onto ``Analysis`` by the embed
+      path for #3297 parity; the default path is unaffected.
+    - ``embed`` (default False): when True, configure the caller's in-memory
+      ``cfg`` under ``root_folder`` (re-entrant, sandboxed) and dispatch there
+      -- the embeddable run path #3287 consumes. Requires ``root_folder``.
+    """
 
     if cfg is None:
         inputfile = validate_arguments_run_methods(inputfile)
@@ -34,6 +57,23 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
     basename = cfg["basename"]
 
     fm = FileManagement()
+
+    if embed:
+        # ---- EMBED PATH (workspace-hub#3308; the crux #3287 consumes) ----
+        if root_folder is None:
+            raise ValueError("engine(embed=True) requires root_folder")
+        cfg_base = configure_embed(
+            cfg, basename, root_folder, log_to_file=log_to_file
+        )
+        cfg_base = fm.router(cfg_base)
+        logging.info(f"{basename}, application ... START")
+        with output_root(root_folder):
+            cfg_base = _dispatch(basename, cfg_base)
+        save_application_cfg(cfg_base=cfg_base)
+        logging.info(f"{basename}, application ... END")
+        return cfg_base
+
+    # ---- DEFAULT PATH (unchanged byte-identical) ----
     if config_flag:
         cfg_base = cfg
         cfg_base = fm.router(cfg_base)
@@ -42,6 +82,21 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
 
     logging.info(f"{basename}, application ... START")
 
+    cfg_base = _dispatch(basename, cfg_base)
+
+    save_application_cfg(cfg_base=cfg_base)
+    logging.info(f"{basename}, application ... END")
+
+    return cfg_base
+
+
+def _dispatch(basename: str, cfg_base: dict) -> dict:
+    """Route ``cfg_base`` to the workflow router for ``basename``.
+
+    Pure refactor (workspace-hub#3308): the if/elif chain extracted verbatim so
+    the default and embed paths share one dispatch site. Same branches, same
+    ``raise Exception`` for an unknown basename.
+    """
     if basename == "stocks":
         stks = Stocks()
         cfg_base = stks.router(cfg_base)
@@ -68,9 +123,6 @@ def engine(inputfile: str = None, cfg: dict = None, config_flag: bool = True) ->
         cfg_base = workflow.router(cfg_base)
     else:
         raise Exception(f"Analysis for basename: {basename} not found. ... FAIL")
-
-    save_application_cfg(cfg_base=cfg_base)
-    logging.info(f"{basename}, application ... END")
 
     return cfg_base
 

--- a/src/assethold/modules/workflow_io.py
+++ b/src/assethold/modules/workflow_io.py
@@ -1,10 +1,35 @@
 from __future__ import annotations
 
 import json
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import asdict, is_dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator, Optional
+
+# Embed output-root rebase (workspace-hub#3308). Default (unset) => byte-identical
+# to pre-#3308 behavior: relative config paths resolve against ``os.getcwd()``.
+# Only the engine embed path sets this (via ``output_root``) so all
+# ``output_path``-based writes land under the injected root. ContextVar => the
+# rebase is re-entrant and isolated per sequential/asyncio-task call.
+_output_root: ContextVar[Optional[str]] = ContextVar(
+    "assethold_output_root", default=None
+)
+
+
+@contextmanager
+def output_root(root: str) -> Iterator[None]:
+    """Rebase relative ``output_path`` writes under ``root`` for the duration.
+
+    Re-entrant: the contextvar token is reset on exit so nested/sequential
+    embed runs do not bleed roots into one another.
+    """
+    token = _output_root.set(root)
+    try:
+        yield
+    finally:
+        _output_root.reset(token)
 
 
 def section(cfg: dict, name: str) -> dict:
@@ -18,6 +43,11 @@ def section(cfg: dict, name: str) -> dict:
 
 def output_path(path: str) -> Path:
     target = Path(path)
+    root = _output_root.get()
+    if root is not None and not target.is_absolute():
+        # Rebase ONLY relative paths, ONLY inside an embed run. Absolute paths
+        # are the caller's explicit choice and are left untouched.
+        target = Path(root) / target
     target.parent.mkdir(parents=True, exist_ok=True)
     return target
 

--- a/tests/common/test_engine_embed_root.py
+++ b/tests/common/test_engine_embed_root.py
@@ -1,0 +1,226 @@
+"""Embed-port tests for assethold's engine (workspace-hub#3308).
+
+Mirrors the assetutilities #3297 embed contract for assethold's OWN engine:
+``engine(cfg=..., embed=True, root_folder=<dir>, log_to_file=False)`` routes
+ALL writes (the ``workflow_io.output_path`` domains, the ``stocks``
+``analysis_root_folder`` domain, and the ``save_application_cfg`` cfg-dump)
+under the injected root, leaving nothing outside it; the default path stays
+byte-identical. Provenance stamps assethold's own version, never assetutilities'.
+
+Every test here exercises assethold-local code (engine, configure_embed,
+workflow_io, provenance) with the workflow routers faked, so no real market
+data / heavy domain fixtures are needed.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from assethold.common.configure_embed import configure_embed
+from assethold.common.provenance import assethold_code_version
+from assethold.engine import engine
+from assethold.modules import workflow_io
+
+
+@pytest.fixture
+def scratch_cwd(tmp_path, monkeypatch):
+    """Run the test body from an isolated cwd so cwd-leaks are detectable."""
+    cwd = tmp_path / "scratch_cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    return cwd
+
+
+def _list_files(root: Path) -> list[Path]:
+    return [p for p in root.rglob("*") if p.is_file()]
+
+
+# --------------------------------------------------------------------------- #
+# AC#1 — embed writes nothing outside root (both write mechanisms + cfg-dump)
+# --------------------------------------------------------------------------- #
+
+def test_embed_workflow_io_writes_under_root(scratch_cwd, tmp_path, monkeypatch):
+    """A workflow_io.output_path-based domain writes ONLY under the injected root."""
+    root = tmp_path / "embed_root"
+
+    class FakeWorkflow:
+        def router(self, cfg):
+            target = workflow_io.output_path("results/portfolio/positions.csv")
+            target.write_text("symbol,qty\nAAA,1\n", encoding="utf-8")
+            return cfg
+
+    monkeypatch.setattr("assethold.engine.PortfolioWorkflow", FakeWorkflow)
+    cfg = {"basename": "portfolio"}
+
+    engine(cfg=cfg, embed=True, root_folder=str(root))
+
+    written = root / "results" / "portfolio" / "positions.csv"
+    assert written.is_file()
+    # Nothing escaped to the scratch cwd.
+    assert _list_files(scratch_cwd) == []
+
+
+def test_embed_stocks_writes_under_root(scratch_cwd, tmp_path, monkeypatch):
+    """The stocks domain (analysis_root_folder) writes under the injected root."""
+    root = tmp_path / "embed_root_stocks"
+    seen = {}
+
+    class FakeStocks:
+        def router(self, cfg):
+            arf = cfg["Analysis"]["analysis_root_folder"]
+            seen["arf"] = arf
+            out = os.path.join(arf, "AAA_data_copy.csv")
+            with open(out, "w", encoding="utf-8") as f:
+                f.write("close\n1.0\n")
+            return cfg
+
+    monkeypatch.setattr("assethold.engine.Stocks", FakeStocks)
+    cfg = {"basename": "stocks"}
+
+    engine(cfg=cfg, embed=True, root_folder=str(root))
+
+    assert seen["arf"] == str(root)  # configure_embed injected the root (no skip-warning path)
+    assert (root / "AAA_data_copy.csv").is_file()
+    assert _list_files(scratch_cwd) == []
+
+
+def test_embed_cfg_dump_under_root(scratch_cwd, tmp_path, monkeypatch):
+    """save_application_cfg's <file_name>.yml lands under <root>/results, not cwd."""
+    root = tmp_path / "embed_root_dump"
+
+    class FakeWorkflow:
+        def router(self, cfg):
+            return cfg
+
+    monkeypatch.setattr("assethold.engine.PortfolioWorkflow", FakeWorkflow)
+    cfg = {"basename": "portfolio"}
+
+    engine(cfg=cfg, embed=True, root_folder=str(root))
+
+    dumps = list((root / "results").glob("portfolio_*.yml"))
+    assert len(dumps) == 1, f"expected one cfg-dump under root/results, got {dumps}"
+    assert _list_files(scratch_cwd) == []
+
+
+# --------------------------------------------------------------------------- #
+# configure_embed contract
+# --------------------------------------------------------------------------- #
+
+def test_embed_sets_config_dir_path(tmp_path):
+    """configure_embed sets cfg['_config_dir_path'] == root_folder (locked contract)."""
+    root = tmp_path / "cfgdir"
+    cfg = configure_embed({"basename": "portfolio"}, "portfolio", str(root))
+    assert cfg["_config_dir_path"] == str(root)
+    assert cfg["Analysis"]["analysis_root_folder"] == str(root)
+    assert cfg["Analysis"]["result_folder"] == os.path.join(str(root), "results")
+    assert cfg["Analysis"]["file_name"].startswith("portfolio_")
+
+
+def test_configure_embed_requires_cfg_and_root():
+    with pytest.raises(ValueError):
+        configure_embed(None, "portfolio", "/tmp/x")
+    with pytest.raises(ValueError):
+        configure_embed({"basename": "portfolio"}, "portfolio", None)
+
+
+def test_configure_embed_preserves_caller_analysis_keys(tmp_path):
+    cfg = configure_embed(
+        {"basename": "portfolio", "Analysis": {"custom": "keep"}},
+        "portfolio",
+        str(tmp_path),
+    )
+    assert cfg["Analysis"]["custom"] == "keep"
+    assert cfg["Analysis"]["analysis_root_folder"] == str(tmp_path)
+
+
+def test_embed_requires_root_folder(scratch_cwd):
+    """engine(embed=True) without root_folder raises ValueError."""
+    with pytest.raises(ValueError):
+        engine(cfg={"basename": "portfolio"}, embed=True)
+
+
+# --------------------------------------------------------------------------- #
+# absolute-path passthrough + re-entrancy
+# --------------------------------------------------------------------------- #
+
+def test_embed_absolute_output_path_not_rebased(scratch_cwd, tmp_path, monkeypatch):
+    """An absolute config output path is left untouched (caller's explicit choice)."""
+    root = tmp_path / "embed_root_abs"
+    abs_target = tmp_path / "abs_outside" / "x.csv"
+
+    class FakeWorkflow:
+        def router(self, cfg):
+            target = workflow_io.output_path(str(abs_target))
+            target.write_text("data\n", encoding="utf-8")
+            return cfg
+
+    monkeypatch.setattr("assethold.engine.PortfolioWorkflow", FakeWorkflow)
+    engine(cfg={"basename": "portfolio"}, embed=True, root_folder=str(root))
+
+    assert abs_target.is_file()
+    # The absolute path must NOT have been rebased under root.
+    assert not (root / "abs_outside").exists()
+
+
+def test_embed_repeated_calls_reentrant(scratch_cwd, tmp_path, monkeypatch):
+    """Two sequential embed runs with different roots stay isolated; contextvar resets."""
+    root_a = tmp_path / "root_a"
+    root_b = tmp_path / "root_b"
+
+    class FakeWorkflow:
+        def router(self, cfg):
+            target = workflow_io.output_path("results/out.csv")
+            target.write_text("x\n", encoding="utf-8")
+            return cfg
+
+    monkeypatch.setattr("assethold.engine.PortfolioWorkflow", FakeWorkflow)
+
+    engine(cfg={"basename": "portfolio"}, embed=True, root_folder=str(root_a))
+    engine(cfg={"basename": "portfolio"}, embed=True, root_folder=str(root_b))
+
+    assert (root_a / "results" / "out.csv").is_file()
+    assert (root_b / "results" / "out.csv").is_file()
+    # No bleed: each root has exactly its own out.csv (plus its cfg-dump).
+    assert not (root_a / "results" / "out.csv").read_text() == ""
+    # Contextvar fully reset after both runs.
+    assert workflow_io._output_root.get() is None
+    assert _list_files(scratch_cwd) == []
+
+
+# --------------------------------------------------------------------------- #
+# AC#2 — default behavior unchanged (backward-compat)
+# --------------------------------------------------------------------------- #
+
+def test_output_path_default_unchanged(scratch_cwd):
+    """With no output_root context, output_path resolves relative -> cwd as today."""
+    target = workflow_io.output_path("results/x.csv")
+    assert target == Path("results/x.csv")  # relative, unchanged
+    assert (scratch_cwd / "results").is_dir()  # parent created under cwd
+
+
+def test_output_path_absolute_default_unchanged(scratch_cwd, tmp_path):
+    abs_p = tmp_path / "abs" / "y.csv"
+    target = workflow_io.output_path(str(abs_p))
+    assert target == abs_p
+
+
+# --------------------------------------------------------------------------- #
+# AC#3 — provenance stamps assethold's version, never assetutilities'
+# --------------------------------------------------------------------------- #
+
+def test_provenance_is_assethold_not_assetutilities():
+    prov = assethold_code_version()
+    assert set(prov) == {"package_version", "git_sha"}
+    # Must be assethold's version, never the assetutilities default.
+    try:
+        import importlib.metadata as md
+
+        au_version = md.version("assetutilities")
+    except Exception:
+        au_version = None
+    ah_version = prov["package_version"]
+    if au_version is not None and ah_version is not None:
+        assert ah_version != au_version or ah_version == md.version("assethold")


### PR DESCRIPTION
Implements workspace-hub#3308 (approved). Mirrors merged assetutilities #3297 embed contract in assethold's engine: additive embed path routing writes under an injected root via new common/configure_embed.py; common/provenance.py stamps code_version('assethold'). Default byte-identical. tests/common/ covers isolation + backward-compat. (Broader basename routing remains #3066's scope.)