### PR TITLE
feat(workflow_api): assethold adopts ResultEnvelope for the portfolio financial workflow (workspace-hub#3287)

### DIFF
--- a/docs/registry/SCHEMA.md
+++ b/docs/registry/SCHEMA.md
@@ -1,0 +1,64 @@
+# assethold workflow registry — schema (v2)
+
+`workflows.yaml` is the single source of truth for assethold's runnable
+workflows. It is consumed by the assethold CLI (`uv run python -m assethold
+<input>`), by `assethold.workflow_api.run_workflow`, and by the cross-repo
+discovery manifest.
+
+## Top-level keys
+
+| Key | Required | Meaning |
+|---|---|---|
+| `schema_version` | yes | `2`. The v2 superset (workspace-hub#3287, co-dependent on #3295) is additive over v1. |
+| `invocation` | yes | The CLI template for running a workflow from its `input`. `{input}` is the **only** substitution token; resolvers (e.g. `deckhand/src/deckhand/capability_smoke.py`, per #3295) substitute the row's `input` path and run the result verbatim. |
+| `repo` | yes | The owning repo slug (`assethold`). Lets the discovery manifest namespace rows. |
+| `workflows` | yes | The list of workflow rows. |
+
+## Per-row keys
+
+| Key | Required | Meaning |
+|---|---|---|
+| `id` | yes | Stable bare id, unique within this registry (e.g. `portfolio-offline`). `run_workflow("<id>")` resolves it against **this** registry — it is NOT a `repo:id@version` cross-repo id. |
+| `basename` | yes | The engine dispatch key (`cfg["basename"]`). |
+| `input` | yes | Example input YAML, repo-root-relative. |
+| `outputs` | yes | **Documentary** list of the CLI-mode output paths (used by the CLI registry smoke test). The in-process runner does NOT trust these names — see "result discovery" below. |
+| `result` | no | Result descriptor (workspace-hub#3282-owned shape). `kind: files` (default) or `kind: in_memory`. Omitting `result` is equivalent to `kind: files`. |
+| `market_data_as_of` | no | Provenance hint: the as-of date of the row's static/offline market inputs. Surfaced as `provenance.data_as_of` when the cfg declares no nearer date. Only meaningful for rows with market inputs (e.g. `portfolio` prices). |
+| `test` | yes | The CLI smoke command. |
+| `runtime` | yes | Execution runtime (`uv-python`). |
+| `request_schema` / `response_schema` | RESERVED | Structured request/response schema slots — **reserved by workspace-hub#3295**, not populated here. |
+
+## Result discovery (in-process `run_workflow`)
+
+`assethold.workflow_api.run_workflow` runs the workflow through the engine
+**embed path** (`engine(cfg=..., embed=True, root_folder=<tempdir>,
+log_to_file=False)`, workspace-hub#3308), which sandboxes **all** writes under an
+injected throwaway root. For `kind: files` the runner discovers the **actually
+emitted** files by globbing that root **recursively** — assethold's portfolio
+router writes its CSVs at the rebased `portfolio.outputs.*` relative paths (e.g.
+`<root>/examples/.../positions.csv`), not under `<root>/results`, so a
+non-recursive `result_folder` glob would miss them.
+
+The engine's `save_application_cfg` cfg-dump `<Analysis.file_name>.yml` (under
+`<root>/results`) is **excluded** from the discovered outputs and the content
+hash — it embeds the tempdir abspath and a run timestamp that would poison
+`result_hash` / `reproducible`.
+
+Each discovered file is content-hashed (`sha256`); `result_hash` is the
+location-independent, content-sensitive hash over the sorted
+`(basename, sha256)` pairs. The repo/example tree is left byte-for-byte
+unchanged (the root is `rmtree`d).
+
+## `data_as_of` provenance contract (market inputs)
+
+Reproducing a financial answer requires the as-of date of the market inputs it
+consumed. assethold's offline prices carry no intrinsic date, so the as-of date
+is a **declared convention**, read in precedence order:
+
+1. `cfg["portfolio"]["prices_as_of"]` — workflow-scoped.
+2. `cfg["Analysis"]["data_as_of"]` — engine-scoped, cross-workflow convention.
+3. `row["market_data_as_of"]` — the registry-row hint.
+
+**Fail-soft, never silent:** when a workflow declares market `prices` but no
+as-of date is found anywhere, `provenance.data_as_of` is `null` AND a warning is
+appended to the envelope. Workflows with no market inputs emit neither.

--- a/docs/registry/workflows.yaml
+++ b/docs/registry/workflows.yaml
@@ -1,4 +1,10 @@
-schema_version: 1
+# schema_version: 2 -- additive v2 superset (workspace-hub#3287, co-dependent #3295):
+#   top-level `invocation:` ({input}-only substitution) + `repo:`;
+#   per-row `result:` descriptor (kind: files default) + `market_data_as_of`.
+# See SCHEMA.md. `request_schema`/`response_schema` are RESERVED for #3295.
+schema_version: 2
+invocation: "uv run python -m assethold {input}"
+repo: assethold
 workflows:
   - id: portfolio-offline
     basename: portfolio
@@ -6,6 +12,9 @@ workflows:
     outputs:
       - examples/workflows/portfolio/outputs/positions.csv
       - examples/workflows/portfolio/outputs/allocation.csv
+    result:
+      kind: files
+    market_data_as_of: "2026-06-27"
     test: uv run python -m assethold examples/workflows/portfolio/input.yml
     runtime: uv-python
   - id: options-covered-call-offline

--- a/examples/workflows/portfolio/input.yml
+++ b/examples/workflows/portfolio/input.yml
@@ -7,6 +7,10 @@ Analysis:
 portfolio:
   data_dir: examples/workflows/portfolio/data
   targets: examples/workflows/portfolio/targets.yml
+  # Declared as-of date for the static offline prices below (workspace-hub#3287
+  # AC#3). Reproducing a financial answer needs the as-of date of its market
+  # inputs; the runner surfaces this as provenance.data_as_of.
+  prices_as_of: "2026-06-27"
   prices:
     VOO: 500.0
     BRKB: 400.0

--- a/src/assethold/workflow_api/__init__.py
+++ b/src/assethold/workflow_api/__init__.py
@@ -1,0 +1,28 @@
+# ABOUTME: Public surface for assethold's deterministic workflow API (workspace-hub#3287).
+"""Deterministic, in-process workflow API for assethold.
+
+assethold has its OWN engine (it does not use assetutilities' ``run_workflow``).
+This package ships an assethold-local ``run_workflow`` that REUSES the shared
+:class:`~assetutilities.workflow_api.envelope.ResultEnvelope` + determinism
+helpers (workspace-hub#3282) and drives assethold's own engine through the
+embed path delivered by workspace-hub#3308
+(``engine(cfg=..., embed=True, root_folder=..., log_to_file=False)``).
+
+The shared ``ResultEnvelope`` is re-exported here so adopters import it from one
+place; it is NOT redefined.
+"""
+
+from assetutilities.workflow_api import ResultEnvelope
+
+from assethold.workflow_api.runner import (
+    build_cfg,
+    extract_result,
+    run_workflow,
+)
+
+__all__ = [
+    "ResultEnvelope",
+    "run_workflow",
+    "build_cfg",
+    "extract_result",
+]

--- a/src/assethold/workflow_api/provenance.py
+++ b/src/assethold/workflow_api/provenance.py
@@ -1,0 +1,46 @@
+# ABOUTME: data_as_of provenance for assethold MARKET inputs (workspace-hub#3287 AC#3).
+"""Market data-as-of provenance for assethold workflows.
+
+Reproducing a financial answer requires the as-of date of the market inputs it
+consumed. assethold's offline portfolio prices carry no intrinsic date, so the
+as-of date is a DECLARED convention read (in precedence order) from:
+
+1. ``cfg["portfolio"]["prices_as_of"]`` -- workflow-scoped declaration.
+2. ``cfg["Analysis"]["data_as_of"]`` -- engine-scoped cross-workflow convention.
+3. ``row["market_data_as_of"]`` -- the registry-row hint.
+
+Fail-SOFT, never silent: when a workflow declares market ``prices`` but no
+as-of date is found anywhere, ``provenance.data_as_of`` is ``None`` AND a
+warning is emitted so the gap is visible in the envelope.
+"""
+
+from __future__ import annotations
+
+
+def _deep_get(cfg, *keys, default=None):
+    cur = cfg
+    for key in keys:
+        if not isinstance(cur, dict) or key not in cur:
+            return default
+        cur = cur[key]
+    return cur
+
+
+def market_data_as_of(cfg: dict, row: dict | None = None):
+    """Return ``(data_as_of, warnings)`` for the market inputs in ``cfg``.
+
+    ``data_as_of`` is the declared as-of date string or ``None``. ``warnings``
+    is non-empty only when market ``prices`` exist without any declared date.
+    """
+    as_of = (
+        _deep_get(cfg, "portfolio", "prices_as_of")
+        or _deep_get(cfg, "Analysis", "data_as_of")
+        or (row or {}).get("market_data_as_of")
+    )
+    has_market_inputs = bool(_deep_get(cfg, "portfolio", "prices"))
+    if has_market_inputs and not as_of:
+        return None, [
+            "workflow declares market 'prices' but no data_as_of "
+            "-> provenance.data_as_of is null"
+        ]
+    return as_of, []

--- a/src/assethold/workflow_api/runner.py
+++ b/src/assethold/workflow_api/runner.py
@@ -1,0 +1,224 @@
+# ABOUTME: assethold-local run_workflow() -> shared ResultEnvelope via the #3308 embed path.
+"""Deterministic, in-process workflow runner for assethold (workspace-hub#3287).
+
+``run_workflow(workflow_id, params=None, cfg=None, verify_reproducible=False)``
+returns a shared :class:`~assetutilities.workflow_api.envelope.ResultEnvelope`.
+
+Design (locked by the #3287 plan): assethold has its OWN engine, so this is an
+assethold-LOCAL ``run_workflow`` that REUSES the shared envelope + determinism
+helpers (workspace-hub#3282) and drives assethold's own engine through the embed
+path (workspace-hub#3308):
+
+``engine(cfg=<built cfg>, embed=True, root_folder=tempfile.mkdtemp(), log_to_file=False)``
+
+Side-effect-freeness comes ENTIRELY from that embed path -- this module adds NO
+cfg-level output redirection of its own. The injected root sandboxes every write
+(the ``workflow_io.output_path`` CSV writers AND the ``save_application_cfg``
+cfg-dump); the runner recursively content-hashes the emitted files and
+``shutil.rmtree``s the root, leaving the repo/example tree byte-for-byte intact.
+
+Unlike assetutilities' runner -- whose ``extract_result`` globs ``result_folder``
+non-recursively -- assethold's portfolio router writes its CSVs at the rebased
+``portfolio.outputs.*`` relative paths (e.g. ``<root>/examples/.../positions.csv``),
+NOT under ``<root>/results``. So this runner globs the WHOLE injected root
+recursively, excluding only the ``<file_name>.yml`` cfg-dump.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import hashlib
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from assetutilities.common.update_deep import update_deep_dictionary
+from assetutilities.workflow_api import (
+    ResultEnvelope,
+    compute_reproducible,
+    input_hash,
+    make_provenance,
+    result_hash,
+)
+
+from assethold.workflow_api.provenance import market_data_as_of
+
+PACKAGE_NAME = "assethold"
+
+
+def _repo_root() -> Path:
+    # runner.py -> workflow_api -> assethold -> src -> <repo root>
+    return Path(__file__).resolve().parents[3]
+
+
+def registry_path() -> Path:
+    return _repo_root() / "docs" / "registry" / "workflows.yaml"
+
+
+def load_registry() -> dict:
+    with open(registry_path()) as fh:
+        return yaml.safe_load(fh)
+
+
+def resolve_registry_row(workflow_id: str) -> dict:
+    registry = load_registry()
+    for row in registry.get("workflows", []):
+        if row.get("id") == workflow_id:
+            return row
+    raise KeyError(
+        f"unknown workflow_id '{workflow_id}' (not in {registry_path()})"
+    )
+
+
+def lookup_row_for_cfg(cfg: dict) -> dict | None:
+    basename = cfg.get("basename")
+    if not basename:
+        return None
+    for row in load_registry().get("workflows", []):
+        if row.get("basename") == basename or row.get("id") == basename:
+            return row
+    return None
+
+
+def resolve_example_path(rel_input: str) -> Path:
+    """Resolve a registry ``input:`` path against the repo root."""
+    return _repo_root() / rel_input
+
+
+def build_cfg(row: dict, params: dict | None) -> dict:
+    """Build the run cfg from a registry row + caller params.
+
+    Starts from the row's ``basename`` + its loaded example ``input``, then
+    deep-merges caller ``params`` (params win).
+    """
+    cfg: dict = {"basename": row["basename"]}
+    input_rel = row.get("input")
+    if input_rel:
+        with open(resolve_example_path(input_rel)) as fh:
+            example_cfg = yaml.safe_load(fh) or {}
+        cfg = update_deep_dictionary(cfg, example_cfg)
+    if params:
+        cfg = update_deep_dictionary(cfg, copy.deepcopy(params))
+    return cfg
+
+
+def _result_kind(row: dict | None) -> str:
+    if not row:
+        return "files"
+    return (row.get("result") or {}).get("kind", "files")
+
+
+def extract_result(cfg_base: dict, root_folder: str, kind: str = "files"):
+    """Return ``(payload, warnings)`` for an embed run.
+
+    For ``kind == "files"`` the ACTUALLY emitted files are discovered by globbing
+    the WHOLE injected ``root_folder`` recursively (assethold's portfolio writes
+    its CSVs at rebased ``portfolio.outputs.*`` paths, not under ``result_folder``).
+    The ``save_application_cfg`` cfg-dump ``<file_name>.yml`` is EXCLUDED -- it
+    embeds the tempdir abspath + a ``start_time`` datetime that would poison the
+    content hash and make ``reproducible`` spuriously False.
+    """
+    analysis = cfg_base.get("Analysis", {}) or {}
+    file_name = analysis.get("file_name", "")
+    cfg_dump_name = file_name + ".yml"
+
+    emitted = sorted(
+        p
+        for p in glob.glob(os.path.join(root_folder, "**", "*"), recursive=True)
+        if os.path.isfile(p) and os.path.basename(p) != cfg_dump_name
+    )
+
+    files = []
+    for path in emitted:
+        with open(path, "rb") as fh:
+            digest = hashlib.sha256(fh.read()).hexdigest()
+        files.append(
+            {
+                "basename": os.path.basename(path),
+                "sha256": digest,
+                "size": os.path.getsize(path),
+            }
+        )
+
+    warns = []
+    if not files:
+        warns.append(
+            f"declared kind:files workflow emitted no files under {root_folder}"
+        )
+    return {"kind": "files", "outputs": files}, warns
+
+
+def _run_once(cfg: dict, kind: str = "files"):
+    """One side-effect-free embed run. Returns ``(payload, warnings, result_hash)``."""
+    # Imported here to keep the (~30s cold) engine import off module load.
+    from assethold.engine import engine as assethold_engine
+
+    root = tempfile.mkdtemp(prefix="ahwf_")
+    try:
+        cfg_base = assethold_engine(
+            cfg=copy.deepcopy(cfg),
+            embed=True,
+            root_folder=root,
+            log_to_file=False,
+        )
+        payload, warns = extract_result(cfg_base, root, kind)
+        return payload, warns, result_hash(payload)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+def run_workflow(
+    workflow_id: str | None = None,
+    params: dict | None = None,
+    cfg: dict | None = None,
+    verify_reproducible: bool = False,
+) -> ResultEnvelope:
+    """Run an assethold registry workflow in-process; return a ResultEnvelope.
+
+    Fail-closed: an unknown id or a router exception is returned as a
+    ``status="error"`` envelope, never raised. Provenance stamps assethold's OWN
+    ``code_version("assethold")`` and the declared market ``data_as_of``.
+    """
+    wid = workflow_id or "(inline-cfg)"
+    try:
+        if cfg is None:
+            row = resolve_registry_row(workflow_id)
+            cfg = build_cfg(row, params)
+        else:
+            cfg = copy.deepcopy(cfg)
+            row = lookup_row_for_cfg(cfg)
+
+        kind = _result_kind(row)
+        as_of, as_of_warns = market_data_as_of(cfg, row)
+        ihash = input_hash(cfg)
+        payload, warns, rhash = _run_once(cfg, kind)
+        repro = compute_reproducible(
+            lambda: _run_once(cfg, kind)[2], rhash, verify_reproducible
+        )
+        return ResultEnvelope(
+            workflow_id=wid,
+            status="ok",
+            result=payload,
+            provenance=make_provenance(
+                ihash, package_name=PACKAGE_NAME, data_as_of=as_of
+            ),
+            determinism={"result_hash": rhash, "reproducible": repro},
+            confidence=None,
+            warnings=warns + as_of_warns,
+        )
+    except Exception as exc:  # fail-closed -> error envelope, never a raw traceback
+        return ResultEnvelope(
+            workflow_id=wid,
+            status="error",
+            result={},
+            provenance=make_provenance(
+                None, package_name=PACKAGE_NAME, data_as_of=None
+            ),
+            determinism={"result_hash": None, "reproducible": None},
+            confidence=None,
+            warnings=[str(exc)],
+        )

--- a/tests/unit/test_workflow_registry.py
+++ b/tests/unit/test_workflow_registry.py
@@ -8,7 +8,7 @@ from assethold.engine import engine
 
 def _registered_workflows():
     registry = yaml.safe_load(Path("docs/registry/workflows.yaml").read_text())
-    assert registry["schema_version"] == 1
+    assert registry["schema_version"] == 2  # v2 superset (workspace-hub#3287)
     return registry["workflows"]
 
 

--- a/tests/workflow_api/test_provenance.py
+++ b/tests/workflow_api/test_provenance.py
@@ -1,0 +1,55 @@
+"""Market data-as-of provenance tests (workspace-hub#3287 AC#3).
+
+Pure-unit: no engine, no market data. Verifies the precedence + fail-soft-warn
+contract of ``market_data_as_of``.
+"""
+
+from __future__ import annotations
+
+from assethold.workflow_api.provenance import market_data_as_of
+
+
+def test_data_as_of_from_portfolio_prices_as_of():
+    cfg = {"portfolio": {"prices_as_of": "2026-06-27", "prices": {"VOO": 1.0}}}
+    as_of, warns = market_data_as_of(cfg, None)
+    assert as_of == "2026-06-27"
+    assert warns == []
+
+
+def test_data_as_of_from_analysis_when_portfolio_absent():
+    cfg = {"Analysis": {"data_as_of": "2026-01-01"}, "portfolio": {"prices": {"VOO": 1.0}}}
+    as_of, warns = market_data_as_of(cfg, None)
+    assert as_of == "2026-01-01"
+    assert warns == []
+
+
+def test_data_as_of_from_registry_row_fallback():
+    cfg = {"portfolio": {"prices": {"VOO": 1.0}}}
+    row = {"market_data_as_of": "2025-12-31"}
+    as_of, warns = market_data_as_of(cfg, row)
+    assert as_of == "2025-12-31"
+    assert warns == []
+
+
+def test_precedence_portfolio_over_analysis_over_row():
+    cfg = {
+        "portfolio": {"prices_as_of": "P", "prices": {"VOO": 1.0}},
+        "Analysis": {"data_as_of": "A"},
+    }
+    row = {"market_data_as_of": "R"}
+    as_of, _ = market_data_as_of(cfg, row)
+    assert as_of == "P"
+
+
+def test_market_inputs_without_as_of_warns_and_none():
+    cfg = {"portfolio": {"prices": {"VOO": 1.0}}}
+    as_of, warns = market_data_as_of(cfg, None)
+    assert as_of is None
+    assert warns and "data_as_of" in warns[0]
+
+
+def test_no_market_inputs_no_warning():
+    cfg = {"portfolio": {"data_dir": "x"}}
+    as_of, warns = market_data_as_of(cfg, None)
+    assert as_of is None
+    assert warns == []

--- a/tests/workflow_api/test_registry.py
+++ b/tests/workflow_api/test_registry.py
@@ -1,0 +1,56 @@
+"""Registry v2-superset tests (workspace-hub#3287 AC#2).
+
+Pure-unit: parses the committed registry; verifies the v2 superset (schema_version,
+top-level invocation, per-row result descriptor + market_data_as_of) without
+running any workflow. Also exercises the runner's registry resolution helpers.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from assethold.workflow_api import runner
+
+
+def _registry():
+    return runner.load_registry()
+
+
+def test_schema_version_is_2():
+    assert _registry()["schema_version"] == 2
+
+
+def test_top_level_invocation_and_repo():
+    reg = _registry()
+    assert reg["invocation"] == "uv run python -m assethold {input}"
+    assert reg["repo"] == "assethold"
+
+
+def test_portfolio_row_has_result_descriptor_and_market_as_of():
+    row = runner.resolve_registry_row("portfolio-offline")
+    assert row["basename"] == "portfolio"
+    assert (row.get("result") or {}).get("kind") == "files"
+    assert row["market_data_as_of"] == "2026-06-27"
+
+
+def test_all_seven_rows_valid_at_v2():
+    rows = _registry()["workflows"]
+    assert len(rows) == 7
+    for row in rows:
+        assert row.get("id")
+        assert row.get("basename")
+        assert row.get("input")
+        # result descriptor optional; when present it must declare a kind
+        if "result" in row:
+            assert row["result"].get("kind") in {"files", "in_memory"}
+
+
+def test_resolve_unknown_id_raises_keyerror():
+    with pytest.raises(KeyError):
+        runner.resolve_registry_row("does-not-exist")
+
+
+def test_lookup_row_for_cfg_by_basename():
+    row = runner.lookup_row_for_cfg({"basename": "portfolio"})
+    assert row is not None and row["id"] == "portfolio-offline"
+    assert runner.lookup_row_for_cfg({}) is None

--- a/tests/workflow_api/test_runner.py
+++ b/tests/workflow_api/test_runner.py
@@ -1,0 +1,191 @@
+"""run_workflow() tests for assethold's workflow API (workspace-hub#3287).
+
+These drive assethold's OWN engine through the #3308 embed path and assert the
+shared ResultEnvelope contract, side-effect-freeness, determinism, and
+assethold-stamped provenance. The golden test pins the portfolio result_hash.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from assetutilities.workflow_api import ResultEnvelope
+
+from assethold.workflow_api import build_cfg, run_workflow
+from assethold.workflow_api import runner as runner_mod
+
+# Pinned golden result_hash for the committed portfolio example (workspace-hub#3287).
+# Captured 2026-06-28 via a verify_reproducible double-run.
+GOLDEN_PORTFOLIO_RESULT_HASH = (
+    "97eff355c696a518f3d474dbf81ade5317f913dd617144945bd11ff982a84b99"
+)
+
+PORTFOLIO_OUTPUTS_DIR = Path("examples/workflows/portfolio/outputs")
+
+
+def _snapshot(d: Path) -> dict:
+    snap = {}
+    if d.is_dir():
+        for root, _, files in os.walk(d):
+            for f in files:
+                p = Path(root) / f
+                snap[str(p)] = hashlib.sha256(p.read_bytes()).hexdigest()
+    return snap
+
+
+@pytest.fixture(scope="module")
+def portfolio_env() -> ResultEnvelope:
+    return run_workflow("portfolio-offline")
+
+
+# --------------------------------------------------------------------------- #
+# envelope shape + provenance
+# --------------------------------------------------------------------------- #
+
+def test_returns_shared_result_envelope(portfolio_env):
+    assert isinstance(portfolio_env, ResultEnvelope)
+    assert portfolio_env.status == "ok"
+    assert portfolio_env.result["kind"] == "files"
+    names = {o["basename"] for o in portfolio_env.result["outputs"]}
+    assert names == {"positions.csv", "allocation.csv"}
+    for o in portfolio_env.result["outputs"]:
+        assert len(o["sha256"]) == 64
+
+
+def test_provenance_data_as_of_populated(portfolio_env):
+    assert portfolio_env.provenance["data_as_of"] == "2026-06-27"
+
+
+def test_provenance_code_version_is_assethold(portfolio_env):
+    cv = portfolio_env.provenance["code_version"]
+    assert set(cv) == {"package_version", "git_sha"}
+    import importlib.metadata as md
+
+    ah = md.version("assethold")
+    au = md.version("assetutilities")
+    assert cv["package_version"] == ah
+    assert cv["package_version"] != au  # never the assetutilities default
+
+
+def test_determinism_fields_present(portfolio_env):
+    assert portfolio_env.determinism["result_hash"] == GOLDEN_PORTFOLIO_RESULT_HASH
+    # default run: reproducible not checked -> honest None (never fabricated True)
+    assert portfolio_env.determinism["reproducible"] is None
+    assert portfolio_env.provenance["input_hash"] is not None
+
+
+def test_data_as_of_missing_warns(monkeypatch):
+    # Inline cfg with market prices but NO declared as-of date anywhere, AND no
+    # registry-row hint (monkeypatched to None) -> fail-soft warn into the envelope.
+    monkeypatch.setattr("assethold.workflow_api.runner.lookup_row_for_cfg", lambda c: None)
+    cfg = {
+        "basename": "portfolio",
+        "Analysis": {"file_name": "portfolio-run"},
+        "portfolio": {
+            "data_dir": "examples/workflows/portfolio/data",
+            "targets": "examples/workflows/portfolio/targets.yml",
+            "prices": {"VOO": 500.0, "BRKB": 400.0},
+            "outputs": {
+                "positions_csv": "examples/workflows/portfolio/outputs/positions.csv",
+                "allocation_csv": "examples/workflows/portfolio/outputs/allocation.csv",
+            },
+        },
+    }
+    env = run_workflow(cfg=cfg)
+    assert env.status == "ok"
+    assert env.provenance["data_as_of"] is None
+    assert any("data_as_of" in w for w in env.warnings)
+
+
+# --------------------------------------------------------------------------- #
+# embed-path consumption + isolation (#3308 consumer gate)
+# --------------------------------------------------------------------------- #
+
+def test_run_drives_embed_path(monkeypatch):
+    captured = {}
+
+    def spy(cfg=None, embed=False, root_folder=None, log_to_file=True, **kw):
+        captured["embed"] = embed
+        captured["root_folder"] = root_folder
+        captured["log_to_file"] = log_to_file
+        return {"Analysis": {"file_name": "portfolio-run"}}
+
+    monkeypatch.setattr("assethold.engine.engine", spy)
+    env = run_workflow("portfolio-offline")
+    assert captured["embed"] is True
+    assert captured["root_folder"] and os.path.isabs(captured["root_folder"])
+    assert captured["log_to_file"] is False
+    # spy wrote nothing -> empty payload + a warning (proves we read from the root)
+    assert env.result["outputs"] == []
+
+
+def test_writes_nothing_outside_tempdir():
+    before = _snapshot(PORTFOLIO_OUTPUTS_DIR)
+    env = run_workflow("portfolio-offline")
+    after = _snapshot(PORTFOLIO_OUTPUTS_DIR)
+    assert env.status == "ok"
+    assert before == after  # repo example tree byte-for-byte unchanged
+
+
+def test_extract_result_excludes_cfg_dump(portfolio_env):
+    for o in portfolio_env.result["outputs"]:
+        assert not o["basename"].endswith(".yml")
+
+
+# --------------------------------------------------------------------------- #
+# determinism: content-sensitivity + golden + reproducible
+# --------------------------------------------------------------------------- #
+
+def test_result_hash_content_sensitive():
+    base = run_workflow("portfolio-offline").determinism["result_hash"]
+    same = run_workflow("portfolio-offline").determinism["result_hash"]
+    perturbed = run_workflow(
+        "portfolio-offline", params={"portfolio": {"prices": {"VOO": 999.0}}}
+    ).determinism["result_hash"]
+    assert base == same
+    assert perturbed != base
+
+
+def test_golden_portfolio_result_hash():
+    env = run_workflow("portfolio-offline")
+    assert env.determinism["result_hash"] == GOLDEN_PORTFOLIO_RESULT_HASH
+
+
+def test_reproducible_true_on_double_run():
+    env = run_workflow("portfolio-offline", verify_reproducible=True)
+    assert env.determinism["reproducible"] is True
+    assert env.determinism["result_hash"] == GOLDEN_PORTFOLIO_RESULT_HASH
+
+
+# --------------------------------------------------------------------------- #
+# build_cfg + fail-closed error envelopes
+# --------------------------------------------------------------------------- #
+
+def test_build_cfg_merges_params_over_example():
+    row = runner_mod.resolve_registry_row("portfolio-offline")
+    cfg = build_cfg(row, {"portfolio": {"prices": {"VOO": 123.0}}})
+    assert cfg["basename"] == "portfolio"
+    assert cfg["portfolio"]["prices"]["VOO"] == 123.0  # param wins
+    assert cfg["portfolio"]["data_dir"]  # example keys preserved
+
+
+def test_unknown_id_returns_error_envelope():
+    env = run_workflow("nope-not-real")
+    assert env.status == "error"
+    assert env.result == {}
+    assert env.warnings and "nope-not-real" in env.warnings[0]
+    assert env.determinism["result_hash"] is None
+
+
+def test_engine_exception_returns_error_envelope(monkeypatch):
+    def boom(*a, **k):
+        raise RuntimeError("router blew up")
+
+    monkeypatch.setattr("assethold.engine.engine", boom)
+    env = run_workflow("portfolio-offline")
+    assert env.status == "error"
+    assert any("router blew up" in w for w in env.warnings)


### PR DESCRIPTION
Implements workspace-hub#3287 — assethold adopts the workflow-API contract for the **portfolio** financial workflow.

Plan: `docs/plans/2026-06-28-issue-3287-assethold-adopt-envelope.md` (status:plan-approved).
Builds on merged prereqs: assetutilities `workflow_api` (#3282) and assethold's engine embed-port (#3308, merged as #72).

## What lands
- **`assethold.workflow_api.run_workflow(workflow_id, params=None, cfg=None, verify_reproducible=False)`** — an assethold-LOCAL runner that **reuses** the shared `ResultEnvelope` + determinism helpers from `assetutilities.workflow_api` and drives assethold's OWN engine through the #3308 embed path (`engine(cfg=..., embed=True, root_folder=mkdtemp(), log_to_file=False)`). The shared `ResultEnvelope` is reused, not redefined.
- **Side-effect-free**: isolation comes entirely from the embed path. The runner globs the injected temp root **recursively** (assethold's portfolio CSVs land at rebased `portfolio.outputs.*` paths, not under `result_folder`), excludes the `save_application_cfg` cfg-dump from the content hash, then `rmtree`s the root. Repo example tree byte-for-byte unchanged.
- **Provenance carries `data_as_of`** for market inputs (AC#3) — precedence `cfg.portfolio.prices_as_of` -> `cfg.Analysis.data_as_of` -> `row.market_data_as_of`; fail-soft-warn when market `prices` exist with no declared date. `code_version("assethold")` stamps assethold's OWN version (0.1.0, != assetutilities 0.1.1).
- **Registry v2 superset** (co-dependent on #3295): `schema_version: 2`, top-level `invocation:`/`repo:`, per-row `result:` descriptor + `market_data_as_of`; `request_schema`/`response_schema` RESERVED. New `docs/registry/SCHEMA.md`.
- Example `portfolio/input.yml` declares `prices_as_of: "2026-06-27"`.

## Determinism
Golden `result_hash` pinned: `97eff355c696a518f3d474dbf81ade5317f913dd617144945bd11ff982a84b99`. `reproducible` is honest-`None` unless `verify_reproducible=True` (measured double-run); a perturbed price flips the hash.

## Tests
- New `tests/workflow_api/` — 26 tests (runner + embed-path spy + isolation + golden + content-sensitivity + provenance + registry + fail-closed error envelopes). All green.
- Regression: `test_workflow_registry.py` (updated to schema_version 2), `test_engine.py`, `test_portfolio.py`, `test_portfolio_beta.py`, `tests/common/test_engine_embed_root.py`, `test_smoke.py`, `test_main_module.py`, `test_market_alerts_workflow.py` — 98 green, no regressions.

Do not merge — pending cross-review.