### PR TITLE
fix(workflow_api): pin LF in workflow outputs so result_hash is platform-independent

### DIFF
--- a/src/assethold/modules/dividend_forecast/dividend_forecast.py
+++ b/src/assethold/modules/dividend_forecast/dividend_forecast.py
@@ -57,7 +57,7 @@ class DividendForecastWorkflow:
                 "year": range(1, forecast.years + 1),
                 "dividend": forecast.dividends,
             }
-        ).to_csv(forecast_file, index=False)
+        ).to_csv(forecast_file, index=False, lineterminator="\n")
         summary_file = write_json(outputs["summary_json"], summary)
 
         return record_outputs(

--- a/src/assethold/modules/fundamentals/fundamentals.py
+++ b/src/assethold/modules/fundamentals/fundamentals.py
@@ -27,7 +27,7 @@ class FundamentalsWorkflow:
         ranked_df = pd.DataFrame(ranked)
 
         ranked_file = output_path(outputs["ranked_csv"])
-        ranked_df.to_csv(ranked_file, index=False)
+        ranked_df.to_csv(ranked_file, index=False, lineterminator="\n")
         report_file = write_text(
             outputs["report_txt"],
             FundamentalsReport().console_table(ranked_df),

--- a/src/assethold/modules/market_alerts/market_alerts.py
+++ b/src/assethold/modules/market_alerts/market_alerts.py
@@ -99,8 +99,13 @@ class MarketAlertsWorkflow:
 def _write_snapshot_csv(path: str, holdings: List[dict]):
     target = output_path(path)
     cols = ["ticker", "usd", "weight", "price", "prev_close", "pct_change", "pe", "dividend_yield"]
+    # newline="" stops the text layer translating, and lineterminator="\n"
+    # overrides csv's own "\r\n" default - without the second half this writes
+    # CRLF on every platform, which is merely inconsistent with the other
+    # workflows today but becomes platform-dependent the moment newline="" is
+    # dropped. Emitted artifacts are content-hashed; see assethold#85.
     with target.open("w", newline="", encoding="utf-8") as fh:
-        w = csv.DictWriter(fh, fieldnames=cols)
+        w = csv.DictWriter(fh, fieldnames=cols, lineterminator="\n")
         w.writeheader()
         for h in holdings:
             w.writerow({k: h.get(k) for k in cols})

--- a/src/assethold/modules/options/options.py
+++ b/src/assethold/modules/options/options.py
@@ -43,5 +43,5 @@ class OptionsWorkflow:
             ).reset_index(drop=True)
 
         output_file = output_path(outputs["opportunities_csv"])
-        table.to_csv(output_file, index=False)
+        table.to_csv(output_file, index=False, lineterminator="\n")
         return record_outputs(cfg, "options", [output_file])

--- a/src/assethold/modules/portfolio/portfolio.py
+++ b/src/assethold/modules/portfolio/portfolio.py
@@ -36,7 +36,16 @@ class PortfolioWorkflow:
 
         positions_file = output_path(outputs["positions_csv"])
         allocation_file = output_path(outputs["allocation_csv"])
-        positions_to_dataframe(positions).to_csv(positions_file, index=False)
-        allocation_to_dataframe(allocation).to_csv(allocation_file, index=False)
+        # lineterminator is pinned to LF so the emitted bytes are identical on
+        # every platform. pandas writes through a text-mode handle, so Windows
+        # would otherwise translate \n to \r\n, changing each file's sha256 and
+        # size -- and these files feed the workflow_api result_hash, which is
+        # contractually a cross-platform determinism value. See assethold#85.
+        positions_to_dataframe(positions).to_csv(
+            positions_file, index=False, lineterminator="\n"
+        )
+        allocation_to_dataframe(allocation).to_csv(
+            allocation_file, index=False, lineterminator="\n"
+        )
 
         return record_outputs(cfg, "portfolio", [positions_file, allocation_file])

--- a/src/assethold/modules/risk_metrics/risk_metrics.py
+++ b/src/assethold/modules/risk_metrics/risk_metrics.py
@@ -29,7 +29,7 @@ class RiskMetricsWorkflow:
         metrics_file = output_path(outputs["metrics_csv"])
         report_file = write_text(outputs["report_txt"], risk.report(risk_free_rate))
         pd.DataFrame([risk.compute(risk_free_rate)]).to_csv(
-            metrics_file, index=False
+            metrics_file, index=False, lineterminator="\n"
         )
 
         return record_outputs(cfg, "risk_metrics", [metrics_file, report_file])

--- a/src/assethold/modules/workflow_io.py
+++ b/src/assethold/modules/workflow_io.py
@@ -52,18 +52,25 @@ def output_path(path: str) -> Path:
     return target
 
 
+# Workflow outputs are content-hashed into the workflow_api result_hash, which is
+# contractually platform-independent. Python's text mode translates "\n" to the
+# platform separator on write, so on Windows every emitted file would gain CRLF
+# and change both its sha256 and its size. Pinning newline="\n" keeps the bytes
+# identical everywhere. See assethold#85.
+#
+# Path.write_text() only grew a newline= parameter in 3.10 and this package still
+# supports 3.9 (requires-python >= 3.9), so these go through open() instead.
 def write_json(path: str, data: Any) -> Path:
     target = output_path(path)
-    target.write_text(
-        json.dumps(to_plain_data(data), indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
+    with target.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write(json.dumps(to_plain_data(data), indent=2, sort_keys=True) + "\n")
     return target
 
 
 def write_text(path: str, text: str) -> Path:
     target = output_path(path)
-    target.write_text(text, encoding="utf-8")
+    with target.open("w", encoding="utf-8", newline="\n") as fh:
+        fh.write(text)
     return target
 
 

--- a/tests/workflow_api/test_runner.py
+++ b/tests/workflow_api/test_runner.py
@@ -156,9 +156,63 @@ def test_golden_portfolio_result_hash():
 
 
 def test_reproducible_true_on_double_run():
-    env = run_workflow("portfolio-offline", verify_reproducible=True)
-    assert env.determinism["reproducible"] is True
-    assert env.determinism["result_hash"] == GOLDEN_PORTFOLIO_RESULT_HASH
+    """Two runs must agree with EACH OTHER.
+
+    Deliberately says nothing about the absolute value: pinning the golden here
+    too meant a platform-specific hash failed this test for a reason that has
+    nothing to do with reproducibility (assethold#85). The golden is asserted
+    once, in test_golden_portfolio_result_hash.
+    """
+    first = run_workflow("portfolio-offline", verify_reproducible=True)
+    second = run_workflow("portfolio-offline", verify_reproducible=True)
+    assert first.determinism["reproducible"] is True
+    assert first.determinism["result_hash"] == second.determinism["result_hash"]
+
+
+def _registry_ids() -> list[str]:
+    return [w["id"] for w in runner_mod.load_registry().get("workflows", [])]
+
+
+@pytest.mark.parametrize("workflow_id", _registry_ids())
+def test_emitted_files_use_lf_line_endings(workflow_id, tmp_path):
+    """Guard the actual cross-platform defect behind assethold#85.
+
+    Python's text mode translates "\\n" to the platform separator on write, so on
+    Windows every emitted file gains CRLF and changes both its sha256 and its
+    size - silently forking the result_hash that the determinism contract
+    promises is platform-independent.
+
+    Asserting on the bytes makes this fail on Windows for an obvious reason
+    instead of surfacing as an opaque golden-hash mismatch, and covering the
+    WHOLE registry means the next workflow to add a CSV/JSON/text output cannot
+    reintroduce it silently. Only portfolio-offline had a golden test when this
+    was found, which is why it was the only one that failed.
+    """
+    import copy
+
+    from assethold.engine import engine as assethold_engine
+
+    row = runner_mod.resolve_registry_row(workflow_id)
+    cfg = build_cfg(row, None)
+    # The same embed call _run_once makes, but into tmp_path so the emitted
+    # bytes survive - _run_once deletes its tempdir before returning.
+    assethold_engine(
+        cfg=copy.deepcopy(cfg),
+        embed=True,
+        root_folder=str(tmp_path),
+        log_to_file=False,
+    )
+
+    emitted = [p for p in tmp_path.rglob("*") if p.is_file()]
+    assert emitted, f"{workflow_id} emitted no files to check"
+    for path in emitted:
+        if path.suffix == ".yml":
+            continue  # engine cfg dump; excluded from the hash by extract_result
+        assert b"\r\n" not in path.read_bytes(), (
+            f"{workflow_id}: {path.name} contains CRLF. Emitted artifacts must be "
+            "byte-identical across platforms - pass lineterminator='\\n' to "
+            "to_csv, or newline='\\n' to open()."
+        )
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Fixes #85.

## Root cause — confirmed empirically, not inferred

Three tests failed on `windows-latest` while passing on ubuntu and macos, with a *stable* wrong hash:

```
golden   (linux/macos): 97eff355c696a518f3d474dbf81ade5317f913dd617144945bd11ff982a84b99
observed (windows)    : a0e2972e802d742ff9eda0bbabdc08774d304e5fac39101bd7daccec459ebb53
```

I reproduced the Windows digest locally by re-hashing the portfolio payload with every `\n` rewritten to `\r\n`:

```
LF   hash: 97eff355…  ==  golden           True
CRLF hash: a0e2972e…  ==  windows observed True
```

Exact match on both. `pandas.to_csv` and `Path.write_text` both write through a text-mode handle, so Windows translates `\n` → `\r\n`. That changes each emitted file's **sha256 and size** — both of which feed `result_hash`, a value the determinism contract promises is platform-independent.

## Fixed at every writer, not just the one under test

Only `portfolio-offline` had a pinned golden, which is why it was the only workflow that failed. **The same latent defect was in four others.**

| Writer | Change |
|---|---|
| `portfolio`, `options`, `risk_metrics`, `fundamentals`, `dividend_forecast` | `to_csv(..., lineterminator="\n")` |
| `workflow_io.write_json` / `write_text` | open with `newline="\n"` |
| `market_alerts` | `csv.DictWriter(..., lineterminator="\n")` |

`write_json`/`write_text` go through `open()` rather than `Path.write_text` because that function's `newline=` parameter needs Python 3.10 and this package still supports 3.9.

**On `market_alerts`, to be precise:** it was *not* causing #85. `csv`'s own default terminator is `\r\n` and `newline=""` suppressed translation, so it wrote CRLF on every platform — consistently, hence deterministically. It is changed for uniformity, and because it becomes platform-dependent the moment someone drops the `newline=""`.

## Tests

`test_emitted_files_use_lf_line_endings` is parametrized over the **whole registry** and asserts on raw bytes. Two reasons:

1. A Windows regression now fails for an obvious stated reason instead of as an opaque hash mismatch.
2. A newly added workflow cannot reintroduce this silently.

It earned its keep immediately — it caught the `market_alerts` case on macOS, which no amount of Linux/macOS golden-hash testing would have surfaced.

`test_reproducible_true_on_double_run` now compares two runs to **each other** rather than to the golden constant. It was asserting the wrong property, which is precisely why a platform-specific hash failed a test that is supposed to be about reproducibility.

## Verification

- **1561 passed**, full suite, macOS, zero failures.
- The golden hash is unchanged and still correct — this makes Windows produce it, rather than moving the goalposts to match Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
