### PR TITLE
fix(docs): retract geo-blocking claim — KAUDA is a dead host, not blocked

### DIFF
--- a/data/gis/portal_status/2026-08-03.json
+++ b/data/gis/portal_status/2026-08-03.json
@@ -1,7 +1,7 @@
 {
   "probed_on": "2026-08-03",
-  "probed_at_utc": "2026-08-03T03:29:03+00:00",
-  "vantage_point": "US network (non-Indian egress)",
+  "probed_at_utc": "2026-08-03T07:29:29+00:00",
+  "vantage_point": "K\u0101kin\u0101da, Andhra Pradesh, IN, AS55836 Reliance Jio Infocomm Limited",
   "results": [
     {
       "key": "bhunaksha",
@@ -65,10 +65,10 @@
       "key": "kauda",
       "label": "KAUDA (Kakinada Urban Dev. Authority)",
       "url": "https://kauda.ap.gov.in/",
-      "why_it_matters": "Master plan + approved layouts for Valasapakala. Geo-blocked as of 2026-08-03.",
-      "access": "india-only",
+      "why_it_matters": "Master plan + approved layouts for Valasapakala. Host DOWN as of 2026-08-03 - fails from inside Kakinada too; KAUDA merged into GUDA.",
+      "access": "host down (KAUDA merged into GUDA)",
       "dns": "164.100.192.133",
-      "verdict": "GEO_BLOCKED",
+      "verdict": "UNREACHABLE",
       "main": {
         "http_status": null,
         "error": "timed out"
@@ -80,9 +80,9 @@
       "label": "KAUDA Kakinada Master Plan PDF",
       "url": "https://kauda.ap.gov.in/documents/MasterPlans/KakinadaMasterPlan.pdf",
       "why_it_matters": "Zoning designation drives buildability on the Kakinada fringe.",
-      "access": "india-only",
+      "access": "host down (KAUDA merged into GUDA)",
       "dns": "164.100.192.133",
-      "verdict": "GEO_BLOCKED",
+      "verdict": "UNREACHABLE",
       "main": {
         "http_status": null,
         "error": "timed out"
@@ -94,9 +94,9 @@
       "label": "KAUDA Zonal Development Plan 2040 PDF",
       "url": "https://kauda.ap.gov.in/documents/downloads/KAKINADA_ZDp_2040-compressed.pdf",
       "why_it_matters": "Forward zoning to 2040.",
-      "access": "india-only",
+      "access": "host down (KAUDA merged into GUDA)",
       "dns": "164.100.192.133",
-      "verdict": "GEO_BLOCKED",
+      "verdict": "UNREACHABLE",
       "main": {
         "http_status": null,
         "error": "timed out"
@@ -225,7 +225,7 @@
       "verdict": "OK",
       "main": {
         "http_status": 200,
-        "bytes": 24722,
+        "bytes": 25683,
         "final_url": "https://ccla.ap.gov.in/",
         "content_type": "text/html; charset=utf-8"
       },
@@ -267,7 +267,7 @@
       "url": "https://services.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/16/26000/47000",
       "why_it_matters": "Satellite basemap used by fetch_basemap_tiles.py.",
       "access": "open (attribution)",
-      "dns": "23.41.120.96",
+      "dns": "104.122.217.63",
       "verdict": "OK",
       "main": {
         "http_status": 200,
@@ -287,7 +287,7 @@
       "verdict": "OK",
       "main": {
         "http_status": 200,
-        "bytes": 210,
+        "bytes": 213,
         "final_url": "https://overpass-api.de/api/status",
         "content_type": "text/plain; charset=utf-8"
       },

--- a/docs/domain/realestate/re_india/india-land-records-sources.md
+++ b/docs/domain/realestate/re_india/india-land-records-sources.md
@@ -1,7 +1,10 @@
 # India land records & mapping — source register (Andhra Pradesh focus)
 
 > **First compiled**: 2026-08-03
-> **Reflects probe date**: 2026-08-03 (US network / non-Indian egress)
+> **Reflects probe date**: 2026-08-03, probed from **Kākināda, Andhra Pradesh**
+> (Reliance Jio). An earlier revision of this page claimed the probes ran from a
+> US network and that several hosts were geo-blocked to non-Indian traffic. That
+> was wrong on both counts — see "Corrections" below.
 > **Live status table**: [`portal-status-log.md`](./portal-status-log.md) —
 > regenerate any time with
 > `python3 scripts/python/india_land_maps/probe_portals.py`
@@ -10,10 +13,29 @@
 > what to do about it; the dated log holds *what was true when*. If the two ever
 > disagree, the log wins — re-probe first, then correct this page.
 
-Reachability below is stated as observed, not as advertised. Several AP
-government hosts are firewalled to Indian IP ranges — that is called out
-explicitly because it changes *who* has to do the fetching, not *whether* the
-data exists.
+Reachability below is stated as observed, not as advertised.
+
+## Corrections (2026-08-03)
+
+Two claims in the first revision of this document were wrong and are retracted:
+
+1. **"KAUDA is geo-blocked to non-Indian traffic."** False. `kauda.ap.gov.in`
+   (164.100.192.133) fails identically *from inside Kakinada itself* — no ICMP,
+   every TCP port filtered. Meanwhile `lgdirectory.gov.in` (164.100.128.239)
+   answers 200 from the same line, so the NIC block routes fine. **The host is
+   simply down.** KAUDA has since been folded into **GUDA** (Godavari Urban
+   Development Authority); `guda.ap.gov.in` currently has no DNS record either,
+   so the master plan needs a different route entirely — DTCP, the KAUDA/GUDA
+   planning wing directly, or a physical office visit.
+2. **"The probes ran from a US network."** They did not. Vantage point was never
+   measured, only assumed. `probe_portals.py` now *detects* it via ipinfo/ip-api
+   and stamps it on every snapshot.
+
+The underlying mistake is worth remembering: **a single vantage point cannot
+distinguish a geo-block from a dead host from an ISP routing failure.** All three
+look like "DNS resolves, TCP times out". Proving a geo-block requires probing
+from two countries. The probe's verdict is now `UNREACHABLE`, which claims only
+what it can support.
 
 ## How fast does this go stale?
 
@@ -136,14 +158,16 @@ mapping, and worth an account if this work continues.
 
 ## Zoning & layout approvals
 
-### KAUDA — `kauda.ap.gov.in` — **geo-blocked**
+### KAUDA / GUDA — `kauda.ap.gov.in` — **host down**
 
 Kakinada Urban Development Authority. This is the correct authority for the
 Kakinada master plan and for approved layouts in the Kakinada urban fringe,
 **including Valasapakala**.
 
-- DNS resolves (`164.100.192.133`) but TCP connections **time out** from a US
-  network, on both 80 and 443. Not a bad path — the host is unreachable.
+- DNS resolves (`164.100.192.133`) but TCP times out on 80, 443 and 8080, and
+  ICMP gets no reply — **including from inside Kakinada**. The host is dead, not
+  filtered by geography. KAUDA is now **GUDA** (Godavari Urban Development
+  Authority), and `guda.ap.gov.in` does not resolve at present.
 - **No Wayback Machine snapshots exist** (`archive.org/wayback/available`
   returns an empty `archived_snapshots` object, and a CDX query for PDFs under
   `kauda.ap.gov.in` returns nothing). There is no archival fallback.
@@ -154,8 +178,8 @@ connection:
 - `https://kauda.ap.gov.in/documents/downloads/KAKINADA_ZDp_2040-compressed.pdf`
   (Zonal Development Plan 2040)
 
-**Action required**: someone on an Indian network (or an Indian VPN egress)
-must fetch these. They cannot be obtained from here.
+**Action required**: not a network problem — the host serving them is gone.
+Try DTCP, the GUDA/KAUDA planning wing directly, or the office in person.
 
 ### DTCP AP — `dtcp.ap.gov.in` — reachable, but its layout links are broken
 
@@ -193,9 +217,10 @@ Related systems:
 4. **Satellite imagery is not a boundary.** Use it to orient, to spot
    encroachment or new construction, and to compare against a sketch — never as
    the basis for a boundary claim.
-5. **Geo-blocking is the main structural obstacle**, not paywalls. The AP
-   planning-authority hosts that matter most (KAUDA) simply do not answer
-   non-Indian traffic.
+5. **Dead hosts and renames are the main structural obstacle**, not paywalls and
+   not geo-blocking. KAUDA became GUDA and its old host went away; guides and
+   search results still point at the corpse. Check whether an authority has been
+   renamed or merged before concluding its data is unavailable.
 
 ---
 

--- a/docs/domain/realestate/re_india/kakinada-valasapakala.md
+++ b/docs/domain/realestate/re_india/kakinada-valasapakala.md
@@ -7,8 +7,10 @@
 > for these tiles is not exposed by the tile API — treat the scene as "recent,
 > undated" and re-pull before relying on it to show current construction)
 >
-> Sections below marked *blocked* were blocked **from a US network on that date**.
-> Re-run the probe before assuming they still are.
+> Sections below marked *blocked* record what could not be fetched on that date.
+> NOTE: an earlier revision attributed the KAUDA failures to geo-blocking from a
+> US network. Both halves were wrong — the probes ran from Kākināda, and the
+> KAUDA host is simply down. Re-run the probe before assuming anything here.
 
 **AOI**: `config/gis/aoi/kakinada_valasapakala.yaml`
 **Data**: `data/gis/kakinada_valasapakala/`
@@ -113,7 +115,8 @@ Both scripts are AOI-driven — point them at a different YAML in
 
 ## What is still missing, and how to get it
 
-Everything below was **blocked from a US network on 2026-08-03**. Re-check with
+Everything below could not be fetched on 2026-08-03 (probing from Kākināda).
+Re-check with
 `python3 scripts/python/india_land_maps/probe_portals.py` before acting — see
 [`india-land-records-sources.md`](./india-land-records-sources.md) for why each
 one behaves the way it does.
@@ -137,9 +140,11 @@ without them the offices cannot pull anything.
 
 ### 2. Kakinada master plan / zonal development plan
 
-KAUDA (`kauda.ap.gov.in`) is the authority covering Valasapakala. The host is
-**geo-blocked** — TCP times out from the US — and has **no Wayback snapshots**,
-so there is no archival fallback. Needs an Indian connection:
+KAUDA (`kauda.ap.gov.in`) is the authority covering Valasapakala. Its host is
+**down** — TCP times out even from inside Kakinada — and there are **no Wayback
+snapshots**, so there is no archival fallback. KAUDA has been folded into
+**GUDA** (Godavari Urban Development Authority), whose domain does not currently
+resolve either. An Indian connection does NOT help; these URLs are dead:
 
 - `https://kauda.ap.gov.in/documents/MasterPlans/KakinadaMasterPlan.pdf`
 - `https://kauda.ap.gov.in/documents/downloads/KAKINADA_ZDp_2040-compressed.pdf`

--- a/docs/domain/realestate/re_india/portal-status-log.md
+++ b/docs/domain/realestate/re_india/portal-status-log.md
@@ -8,8 +8,8 @@ python3 scripts/python/india_land_maps/probe_portals.py
 
 Every finding about these portals is perishable: access rules, hostnames
 and published links change without notice. This log records what was
-actually true on each probe date, from a **non-Indian network** — vantage
-point matters, because several hosts are firewalled to Indian IP ranges.
+actually true on each probe date, from the vantage point stated on that
+snapshot — "unreachable" is meaningless without knowing from where.
 
 Verdicts:
 
@@ -17,13 +17,18 @@ Verdicts:
 |---|---|
 | `OK` | reachable |
 | `CATCH_ALL` | 200 for every path - login wall, content NOT accessible |
-| `GEO_BLOCKED` | DNS resolves but connection times out (blocked to non-Indian traffic) |
+| `UNREACHABLE` | DNS resolves but TCP never connects - dead host, firewall or routing; a single vantage point CANNOT distinguish these |
 | `NO_DNS` | hostname does not resolve at all |
 | `GONE_404` | published link is dead |
 | `FORBIDDEN` | authentication required |
 
 `CATCH_ALL` is the one to watch: those hosts answer **HTTP 200 for a path
 that cannot exist**, so a 200 there is not evidence of anything.
+
+The **Vantage point** on each snapshot is DETECTED, not assumed. An earlier
+version of this log asserted hosts were *geo-blocked to non-Indian traffic*
+while the probe was in fact running from Kakinada, Andhra Pradesh. Treat
+`UNREACHABLE` as "could not connect", nothing more.
 
 The **Access** column is a documented human judgement, not a probe result.
 Reachability and access are different axes: BhuNaksha answers 200 and 404s
@@ -34,16 +39,16 @@ whenever a reachability verdict changes.
 
 ## 2026-08-03
 
-Probed 2026-08-03T03:29:03+00:00 from: US network (non-Indian egress)
+Probed 2026-08-03T07:29:29+00:00 from: Kākināda, Andhra Pradesh, IN, AS55836 Reliance Jio Infocomm Limited
 
 | Portal | Reachability | HTTP | Access | Notes |
 |---|---|---|---|---|
 | [BhuNaksha AP (cadastral viewer)](https://bhunaksha.ap.gov.in/) | `OK` | 200 | login / counter | Authoritative AP cadastral maps / FMB. The only real plot-boundary source. |
 | [BhuNaksha REST layer](https://bhunaksha.ap.gov.in/bhunakshalpm/rest/MapInfo/getDistrictCodes) | `GONE_404` | 404 | login | If this ever answers anonymously again, bulk map retrieval becomes possible. |
 | [MeeBhoomi (Adangal / 1-B / ROR)](https://meebhoomi.ap.gov.in/) | `CATCH_ALL` | 200 | login / counter | Record of Rights and village maps. |
-| [KAUDA (Kakinada Urban Dev. Authority)](https://kauda.ap.gov.in/) | `GEO_BLOCKED` | — (timed out) | india-only | Master plan + approved layouts for Valasapakala. Geo-blocked as of 2026-08-03. |
-| [KAUDA Kakinada Master Plan PDF](https://kauda.ap.gov.in/documents/MasterPlans/KakinadaMasterPlan.pdf) | `GEO_BLOCKED` | — (timed out) | india-only | Zoning designation drives buildability on the Kakinada fringe. |
-| [KAUDA Zonal Development Plan 2040 PDF](https://kauda.ap.gov.in/documents/downloads/KAKINADA_ZDp_2040-compressed.pdf) | `GEO_BLOCKED` | — (timed out) | india-only | Forward zoning to 2040. |
+| [KAUDA (Kakinada Urban Dev. Authority)](https://kauda.ap.gov.in/) | `UNREACHABLE` | — (timed out) | host down (KAUDA merged into GUDA) | Master plan + approved layouts for Valasapakala. Host DOWN as of 2026-08-03 - fails from inside Kakinada too; KAUDA merged into GUDA. |
+| [KAUDA Kakinada Master Plan PDF](https://kauda.ap.gov.in/documents/MasterPlans/KakinadaMasterPlan.pdf) | `UNREACHABLE` | — (timed out) | host down (KAUDA merged into GUDA) | Zoning designation drives buildability on the Kakinada fringe. |
+| [KAUDA Zonal Development Plan 2040 PDF](https://kauda.ap.gov.in/documents/downloads/KAKINADA_ZDp_2040-compressed.pdf) | `UNREACHABLE` | — (timed out) | host down (KAUDA merged into GUDA) | Forward zoning to 2040. |
 | [DTCP AP (Town & Country Planning)](https://dtcp.ap.gov.in/) | `OK` | 200 | open | Statewide planning directorate. |
 | [DTCP approved-layouts page](http://dtcp.ap.gov.in/webdtcp/approvedlayouts.html) | `GONE_404` | 404 | open (link dead) | Linked from the DTCP homepage but 404 as of 2026-08-03 - recheck periodically. |
 | [DTCP unauthorised-layout list (PDF)](https://dtcp.ap.gov.in/downloads/Unauthorised%20Layout%20Details.pdf) | `GONE_404` | 404 | open (link dead) | Linked from the DTCP homepage but 404 as of 2026-08-03 - recheck periodically. |

--- a/scripts/python/india_land_maps/probe_portals.py
+++ b/scripts/python/india_land_maps/probe_portals.py
@@ -23,9 +23,17 @@ Interpreting results - two traps this script is built to catch:
   a deliberately absent control path; if a real path returns the same byte
   count as the control, the host is flagged CATCH_ALL rather than OK.
 
-  GEO-BLOCK: some hosts resolve in DNS but never complete a TCP handshake from
-  outside India. That is reported as GEO_BLOCKED (DNS ok, connect fails), which
-  is a materially different problem from a dead host.
+  UNREACHABLE: some hosts resolve in DNS but never complete a TCP handshake.
+  That is reported as UNREACHABLE - deliberately NOT as "geo-blocked". DNS
+  resolving while TCP fails is equally consistent with a dead host, a firewall,
+  or an ISP routing problem, and a probe cannot tell those apart. The earlier
+  version of this script called it GEO_BLOCKED and was wrong: kauda.ap.gov.in
+  was labelled geo-blocked when in fact the host is simply down - it fails
+  identically from inside Kakinada, its own city. Diagnosing geo-blocking needs
+  a probe from two different countries, which this script does not do.
+
+The vantage point is DETECTED, not assumed, and recorded with every snapshot -
+"blocked from where?" is meaningless without it.
 """
 
 from __future__ import annotations
@@ -91,8 +99,8 @@ TARGETS = [
         "KAUDA (Kakinada Urban Dev. Authority)",
         "https://kauda.ap.gov.in/",
         None,
-        "Master plan + approved layouts for Valasapakala. Geo-blocked as of 2026-08-03.",
-        "india-only",
+        "Master plan + approved layouts for Valasapakala. Host DOWN as of 2026-08-03 - fails from inside Kakinada too; KAUDA merged into GUDA.",
+        "host down (KAUDA merged into GUDA)",
     ),
     (
         "kauda_masterplan",
@@ -100,7 +108,7 @@ TARGETS = [
         "https://kauda.ap.gov.in/documents/MasterPlans/KakinadaMasterPlan.pdf",
         None,
         "Zoning designation drives buildability on the Kakinada fringe.",
-        "india-only",
+        "host down (KAUDA merged into GUDA)",
     ),
     (
         "kauda_zdp",
@@ -108,7 +116,7 @@ TARGETS = [
         "https://kauda.ap.gov.in/documents/downloads/KAKINADA_ZDp_2040-compressed.pdf",
         None,
         "Forward zoning to 2040.",
-        "india-only",
+        "host down (KAUDA merged into GUDA)",
     ),
     (
         "dtcp",
@@ -209,6 +217,29 @@ TARGETS = [
 ]
 
 
+def detect_vantage_point() -> str:
+    """Report where this probe is actually running from.
+
+    Assuming the vantage point is how the 2026-08-03 survey mislabelled a dead
+    host as geo-blocked. Detect it instead; fall back to an explicit unknown
+    rather than a guess.
+    """
+    for url, fields in (
+        ("https://ipinfo.io/json", ("city", "region", "country", "org")),
+        ("http://ip-api.com/json/", ("city", "regionName", "country", "isp")),
+    ):
+        try:
+            req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+            with urllib.request.urlopen(req, timeout=15) as resp:
+                d = json.loads(resp.read().decode("utf-8"))
+            parts = [str(d[f]) for f in fields if d.get(f)]
+            if parts:
+                return ", ".join(parts)
+        except Exception:  # noqa: BLE001 - any failure just means try the next
+            continue
+    return "UNKNOWN (detection failed)"
+
+
 def resolve(host: str) -> str | None:
     try:
         return socket.gethostbyname(host)
@@ -243,9 +274,10 @@ def fetch(url: str) -> dict:
 def classify(url: str, main: dict, control: dict | None, dns: str | None) -> str:
     if main.get("http_status") is None:
         if dns:
-            # Name resolves but the connection never completes - the signature of
-            # an IP-range firewall rather than a decommissioned host.
-            return "GEO_BLOCKED"
+            # Name resolves but the connection never completes. Do NOT call this
+            # geo-blocking: a dead host, a firewall and an ISP routing failure
+            # all look identical from a single vantage point.
+            return "UNREACHABLE"
         return "NO_DNS"
     status = main["http_status"]
     if control and control.get("http_status") == 200 and main.get("bytes") == control.get("bytes"):
@@ -262,7 +294,7 @@ def classify(url: str, main: dict, control: dict | None, dns: str | None) -> str
 VERDICT_NOTE = {
     "OK": "reachable",
     "CATCH_ALL": "200 for every path - login wall, content NOT accessible",
-    "GEO_BLOCKED": "DNS resolves but connection times out (blocked to non-Indian traffic)",
+    "UNREACHABLE": "DNS resolves but TCP never connects - dead host, firewall or routing; a single vantage point CANNOT distinguish these",
     "NO_DNS": "hostname does not resolve at all",
     "GONE_404": "published link is dead",
     "FORBIDDEN": "authentication required",
@@ -298,7 +330,7 @@ def probe_all() -> dict:
     return {
         "probed_on": date.today().isoformat(),
         "probed_at_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
-        "vantage_point": "US network (non-Indian egress)",
+        "vantage_point": detect_vantage_point(),
         "results": results,
     }
 
@@ -316,8 +348,8 @@ def render_markdown(records: list[dict]) -> str:
         "",
         "Every finding about these portals is perishable: access rules, hostnames",
         "and published links change without notice. This log records what was",
-        "actually true on each probe date, from a **non-Indian network** — vantage",
-        "point matters, because several hosts are firewalled to Indian IP ranges.",
+        "actually true on each probe date, from the vantage point stated on that",
+        "snapshot — \"unreachable\" is meaningless without knowing from where.",
         "",
         "Verdicts:",
         "",
@@ -330,6 +362,11 @@ def render_markdown(records: list[dict]) -> str:
         "",
         "`CATCH_ALL` is the one to watch: those hosts answer **HTTP 200 for a path",
         "that cannot exist**, so a 200 there is not evidence of anything.",
+        "",
+        "The **Vantage point** on each snapshot is DETECTED, not assumed. An earlier",
+        "version of this log asserted hosts were *geo-blocked to non-Indian traffic*",
+        "while the probe was in fact running from Kakinada, Andhra Pradesh. Treat",
+        "`UNREACHABLE` as \"could not connect\", nothing more.",
         "",
         "The **Access** column is a documented human judgement, not a probe result.",
         "Reachability and access are different axes: BhuNaksha answers 200 and 404s",

--- a/tests/test_india_land_maps.py
+++ b/tests/test_india_land_maps.py
@@ -251,9 +251,40 @@ class TestProbeVerdicts:
         control = {"http_status": 404, "bytes": 2667}
         assert probe.classify("u", main, control, "1.2.3.4") == "OK"
 
-    def test_geo_block_is_dns_ok_but_connect_fails(self):
+    def test_dns_ok_but_connect_fails_is_unreachable_not_geo_blocked(self):
+        """Regression for the wrong call made on 2026-08-03.
+
+        This assertion used to demand "GEO_BLOCKED", encoding the belief that
+        DNS-resolves-plus-TCP-fails proves an IP-range block. It does not: a dead
+        host, a firewall and an ISP routing failure are indistinguishable from a
+        single vantage point. kauda.ap.gov.in was labelled geo-blocked and was in
+        fact simply down - it failed identically from inside its own city.
+
+        The verdict must claim only what one probe can support.
+        """
         failed = {"http_status": None, "error": "timed out"}
-        assert probe.classify("u", failed, None, "164.100.192.133") == "GEO_BLOCKED"
+        assert probe.classify("u", failed, None, "164.100.192.133") == "UNREACHABLE"
+
+    def test_no_verdict_asserts_geo_blocking(self):
+        """No verdict may claim geo-blocking - the probe cannot establish it."""
+        assert not any("GEO" in v.upper() for v in probe.VERDICT_NOTE), (
+            "a single-vantage-point probe cannot prove a geo-block; "
+            "use UNREACHABLE and record the vantage point instead"
+        )
+
+    def test_vantage_point_is_detected_not_hardcoded(self):
+        """The snapshot's vantage point must come from detection, not a literal.
+
+        Assuming it (as 'US network') is precisely what produced the wrong
+        published conclusion.
+        """
+        import inspect
+
+        src = inspect.getsource(probe)
+        assert "def detect_vantage_point" in src
+        assert '"vantage_point": detect_vantage_point()' in src, (
+            "vantage_point must be detected at probe time"
+        )
 
     def test_no_dns_when_name_does_not_resolve(self):
         failed = {"http_status": None, "error": "nodename nor servname provided"}


### PR DESCRIPTION
Retracts two wrong claims from the 2026-08-03 survey, published in #83.

**1. "KAUDA is geo-blocked to non-Indian traffic" — false.**
`kauda.ap.gov.in` (164.100.192.133) fails identically **from inside Kakinada**: no ICMP, TCP filtered on 80/443/8080. `lgdirectory.gov.in` (164.100.128.239) returns 200 from the same line, so the NIC block routes fine. The host is simply **down**. KAUDA has been folded into **GUDA**, and `guda.ap.gov.in` has no DNS record either — so an Indian connection does not help and never would have.

**2. "Probed from a US network" — false.** Vantage point was never measured, only assumed. It was Kākināda, Andhra Pradesh (Reliance Jio) throughout.

## Root cause

`classify()` inferred `GEO_BLOCKED` from *"DNS resolves + TCP fails"*. That inference is unsound — a dead host, a firewall, and an ISP routing failure are **indistinguishable from a single vantage point**. Proving a geo-block needs probes from two countries.

## Fixes

- `GEO_BLOCKED` → `UNREACHABLE`, claiming only what one probe supports
- `detect_vantage_point()` resolves egress via ipinfo/ip-api and stamps it on every snapshot; explicit `UNKNOWN` on failure rather than a guess
- log header no longer hardcodes "non-Indian network"
- both prose docs carry a visible **Corrections** section rather than a silent edit

🤖 Generated with [Claude Code](https://claude.com/claude-code)